### PR TITLE
Fix #34

### DIFF
--- a/source/lib/vagrant-openstack-provider/action/read_ssh_info.rb
+++ b/source/lib/vagrant-openstack-provider/action/read_ssh_info.rb
@@ -18,30 +18,10 @@ module VagrantPlugins
         end
 
         def read_ssh_info(env)
-          client = env[:openstack_client]
-          machine = env[:machine]
           config = env[:machine].provider_config
-          @logger.debug(config)
-          return nil if machine.id.nil?
-          begin
-            details = client.get_server_details(env, machine.id)
-          rescue Exception => e
-            # The machine can't be found
-            @logger.error(e)
-            @logger.info("Machine couldn't be found, assuming it got destroyed.")
-            machine.id = nil
-            return nil
-          end
-
-          for addr in details['addresses']['private']
-            if addr['OS-EXT-IPS:type'] == 'floating'
-              host = addr['addr']
-            end
-          end
-
           return {
             # Usually there should only be one public IP
-            :host => host,
+            :host => config.floating_ip,
             :port => 22,
             :username => config.ssh_username
           }


### PR DESCRIPTION
As long as we need to pre-provision floating IP and specify it
in the Vagrantfile there's no need to request Nova or Neutron
to get a public IP address for SSH. Just get it from configuration.
