### PR TITLE
issue119: add unit test for rsync path under windows.

### DIFF
--- a/source/lib/vagrant-openstack-provider/action/sync_folders.rb
+++ b/source/lib/vagrant-openstack-provider/action/sync_folders.rb
@@ -63,9 +63,7 @@ module VagrantPlugins
 
             # If on Windows, modify the path to work with cygwin rsync
             if @host_os =~ /mswin|mingw|cygwin/
-              hostpath = hostpath.sub(/^([A-Za-z]):\//) do
-                "/cygdrive/#{Regexp.last_match[1].downcase}/"
-              end
+              hostpath = add_cygdrive_prefix_to_path(hostpath)
             end
 
             env[:ui].info(I18n.t('vagrant_openstack.rsync_folder', hostpath: hostpath, guestpath: guestpath))
@@ -115,6 +113,12 @@ module VagrantPlugins
         def ssh_key_options(ssh_info)
           # Ensure that `private_key_path` is an Array (for Vagrant < 1.4)
           Array(ssh_info[:private_key_path]).map { |path| "-i '#{path}' " }.join
+        end
+
+        def add_cygdrive_prefix_to_path(hostpath)
+          hostpath.downcase.sub(/^([a-z]):\//) do
+            "/cygdrive/#{Regexp.last_match[1]}/"
+          end
         end
       end
     end

--- a/source/spec/vagrant-openstack-provider/action/sync_folders_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/sync_folders_spec.rb
@@ -1,0 +1,24 @@
+require 'vagrant-openstack-provider/spec_helper'
+require 'log4r'
+require 'rbconfig'
+require 'vagrant/util/subprocess'
+
+include VagrantPlugins::Openstack::Action
+
+describe VagrantPlugins::Openstack::Action::RsyncFolders do
+
+  before :each do
+    RsyncFolders.send(:public, *RsyncFolders.private_instance_methods)
+    app = double('app')
+    app.stub(:call).with(anything)
+    @action = RsyncFolders.new(app, nil)
+  end
+
+  describe 'convert_path_to_windows_format' do
+    context 'hostpath in starting with C:/ ' do
+      it 'returns hostpath starting with /cygdrive/c/ and in downcase' do
+        expect(@action.add_cygdrive_prefix_to_path('C:/Directory')).to eq '/cygdrive/c/directory'
+      end
+    end
+  end
+end


### PR DESCRIPTION
For some, still, uncleared reasons, the computation of the hostpath in one method embedding :
-a replacement , a concatenation  and  a downcase throws an error. 

So I have splitted the computation with three assignements beginning by a downcase. 
Readability is enhanced with no more error.
