### PR TITLE
Windows RSYNC

### DIFF
--- a/source/lib/vagrant-openstack-provider/action/sync_folders.rb
+++ b/source/lib/vagrant-openstack-provider/action/sync_folders.rb
@@ -60,7 +60,7 @@ module VagrantPlugins
 
             # If on Windows, modify the path to work with cygwin rsync
             if @host_os =~ /mswin|mingw|cygwin/
-              hostpath = hostpath.sub(/^([A-Za-z]):\//) do |match|
+              hostpath = hostpath.sub(/^([A-Za-z]):\//) do
                 "/cygdrive/#{Regexp.last_match[1].downcase}/"
               end
             end


### PR DESCRIPTION
Fix: Windows drive substitution
Adding right permissions in the execution
Exclude .git data in rsync
