### PR TITLE
Allow public and private networks to be specified

### DIFF
--- a/source/lib/vagrant-openstack-provider/config_resolver.rb
+++ b/source/lib/vagrant-openstack-provider/config_resolver.rb
@@ -62,12 +62,12 @@ module VagrantPlugins
         env[:ui].info(I18n.t('vagrant_openstack.finding_networks'))
         return resolve_networks_without_network_service(env) unless env[:openstack_client].session.endpoints.key? :network
 
-        private_networks = env[:openstack_client].neutron.get_private_networks(env)
-        private_network_ids = private_networks.map { |v| v.id }
+        all_networks = env[:openstack_client].neutron.get_all_networks(env)
+        all_network_ids = all_networks.map { |v| v.id }
 
         networks = []
         config.networks.each do |network|
-          networks << resolve_network(network, private_networks, private_network_ids)
+          networks << resolve_network(network, all_networks, all_network_ids)
         end
         @logger.debug("Resolved networks : #{networks.to_json}")
         networks

--- a/source/spec/vagrant-openstack-provider/config_resolver_spec.rb
+++ b/source/spec/vagrant-openstack-provider/config_resolver_spec.rb
@@ -35,6 +35,16 @@ describe VagrantPlugins::Openstack::ConfigResolver do
          Item.new('007', 'net-07-08'),
          Item.new('008', 'net-07-08')]
       end
+      neutron.stub(:get_all_networks).with(anything) do
+        [Item.new('001', 'net-01'),
+         Item.new('002', 'net-02'),
+         Item.new('003', 'net-03'),
+         Item.new('004', 'net-04'),
+         Item.new('005', 'net-05'),
+         Item.new('006', 'net-06'),
+         Item.new('007', 'net-07-08'),
+         Item.new('008', 'net-07-08')]
+      end
     end
   end
 


### PR DESCRIPTION
This is in regards to issue #129 

Swap call in config_resolver from get_private_networks() to get_all_networks().  Add stub for :get_all_networks in config_resolver_spec so tests will pass
