### PR TITLE
Override default merge method for our configuration

### DIFF
--- a/source/lib/vagrant-openstack-provider/config.rb
+++ b/source/lib/vagrant-openstack-provider/config.rb
@@ -177,20 +177,19 @@ module VagrantPlugins
 
         # Set all of our instance variables on the new class
         [self, other].each do |obj|
-          # rubocop:disable Style/Next
           obj.instance_variables.each do |key|
-            # rubocop:enable Style/Next
             # Ignore keys that start with a double underscore. This allows
             # configuration classes to still hold around internal state
             # that isn't propagated.
-            unless key.to_s.start_with?('@__')
-              # Don't set the value if it is the unset value, either.
-              value = obj.instance_variable_get(key)
-              if [:@networks, :@volumes, :@rsync_includes].include? key
-                result.instance_variable_set(key, value) unless value.empty?
-              else
-                result.instance_variable_set(key, value) if value != UNSET_VALUE
-              end
+            next if key.to_s.start_with?('@__')
+
+            # Don't set the value if it is the unset value, either.
+            value = obj.instance_variable_get(key)
+            print key
+            if [:@networks, :@volumes, :@rsync_includes].include? key
+              result.instance_variable_set(key, value) unless value.empty?
+            else
+              result.instance_variable_set(key, value) if value != UNSET_VALUE
             end
           end
         end

--- a/source/spec/vagrant-openstack-provider/config_spec.rb
+++ b/source/spec/vagrant-openstack-provider/config_spec.rb
@@ -62,6 +62,55 @@ describe VagrantPlugins::Openstack::Config do
     end
   end
 
+  describe 'merge' do
+    let(:foo_class) do
+      Class.new(described_class) do
+        attr_accessor :networks
+      end
+    end
+
+    subject { foo_class.new }
+
+    context 'with original network not empty' do
+      it 'should overidde the config' do
+        one = foo_class.new
+        one.networks = ['foo']
+
+        two = foo_class.new
+        two.networks = ['bar']
+
+        result = one.merge(two)
+        result.networks.should =~ ['bar']
+      end
+    end
+
+    context 'with original network empty' do
+      it 'should add the network to the existing list' do
+        one = foo_class.new
+        one.networks = []
+
+        two = foo_class.new
+        two.networks = ['bar']
+
+        result = one.merge(two)
+        result.networks.should =~ ['bar']
+      end
+    end
+
+    context 'with original network not empty and new empty' do
+      it 'should keep the original network' do
+        one = foo_class.new
+        one.networks = ['foo']
+
+        two = foo_class.new
+        two.networks = []
+
+        result = one.merge(two)
+        result.networks.should =~ ['foo']
+      end
+    end
+  end
+
   describe 'validation' do
     let(:machine) { double('machine') }
     let(:validation_errors) { subject.validate(machine)['Openstack Provider'] }


### PR DESCRIPTION
For config values of type Array, we don't check for UNSET_VALUE
but only if the array is empty or not

Fix #146
