### PR TITLE
Add BatchMode to vagrant ssh options

### DIFF
--- a/source/lib/vagrant-openstack-provider/action/wait_accessible.rb
+++ b/source/lib/vagrant-openstack-provider/action/wait_accessible.rb
@@ -41,6 +41,9 @@ module VagrantPlugins
             end
 
             env[:ssh_run_command] = 'exit 0'
+            env[:ssh_opts] = {
+              extra_args: ['-o', 'BatchMode=yes']
+            }
             @ssh.call(env)
             return true if env[:ssh_run_exit_status] == 0
 


### PR DESCRIPTION
This way, when ssh prompt us for the password, for instance when the ssh-key
has not yet been setup, we fail the ssh action, and vagrant will retry until
the ssh-key is installed and ssh is really available
