### PR TITLE
Allow lists in config values

### DIFF
--- a/source/lib/vagrant-openstack-provider/config_resolver.rb
+++ b/source/lib/vagrant-openstack-provider/config_resolver.rb
@@ -275,17 +275,21 @@ module VagrantPlugins
         { id: volume_id, device: device }
       end
 
-      # This method finds a matching _thing_ in a collection of
-      # _things_. This works matching if the ID or NAME equals to
-      # `name`. Or, if `name` is a regexp, a partial match is chosen
+      # This method finds any matching _thing_ from a list of names
+      # in a collection of _things_. The first to match is the returned
+      # one. Names in list can be a regexp, a partial match is chosen
       # as well.
-      def find_matching(collection, name)
-        collection.each do |single|
-          return single if single.id == name
-          return single if single.name == name
-          return single if name.is_a?(Regexp) && name =~ single.name
+
+      def find_matching(collection, name_or_names)
+        name_or_names = [name_or_names] if name_or_names.class != Array
+        name_or_names.each do |name|
+          collection.each do |single|
+            return single if single.id == name
+            return single if single.name == name
+            return single if name.is_a?(Regexp) && name =~ single.name
+          end
         end
-        @logger.error "Element '#{name}' not found in collection #{collection}"
+        @logger.error "No element of '#{name_or_names}' found in collection #{collection}"
         nil
       end
     end

--- a/source/spec/vagrant-openstack-provider/config_resolver_spec.rb
+++ b/source/spec/vagrant-openstack-provider/config_resolver_spec.rb
@@ -160,6 +160,16 @@ describe VagrantPlugins::Openstack::ConfigResolver do
         @action.resolve_flavor(env).should eq(Flavor.new('fl-002', 'flavor-02', 4, 2048, 50))
       end
     end
+    context 'with list' do
+      it 'returns the first matching flavor' do
+        config.stub(:flavor) { %w(not-existing flavor-02 flavor-01) }
+        nova.stub(:get_all_flavors).with(anything) do
+          [Flavor.new('fl-001', 'flavor-01', 2, 1024, 10),
+           Flavor.new('fl-002', 'flavor-02', 4, 2048, 50)]
+        end
+        @action.resolve_flavor(env).should eq(Flavor.new('fl-002', 'flavor-02', 4, 2048, 50))
+      end
+    end
     context 'with invalid identifier' do
       it 'raise an error' do
         config.stub(:flavor) { 'not-existing' }


### PR DESCRIPTION
This may allow, for example using a list of flavors which could
not be compatible across clouds, but allowing to fall back.

For example:
  os.flavor = ['mylab.4cpu.8gb.20hd', 'm1.large']

Will try the first one, and then the next one, if not found.