### PR TITLE
Enhance IP resolution for SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ end
 
 * `floating_ip_pool_always_allocate` - if set to true, vagrant will always allocate floating ip instead of trying to reuse unassigned ones
 
+__N.B.__
+> If the instance have a floating IP, this IP will be used to SSH into the instance.
+
 #### Networks
 
 * `networks` - Network list the server must be connected on. Can be omitted if only one private network exists
@@ -175,6 +178,10 @@ config.vm.provider :openstack do |os|
   ...
 end
 ```
+
+__N.B.__
+> If the instance does not have a floating IP, the IP of the
+> first network in the list will be used to SSH into the instance
 
 #### Volumes
 

--- a/source/spec/vagrant-openstack-provider/action/read_ssh_info_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/read_ssh_info_spec.rb
@@ -25,8 +25,17 @@ describe VagrantPlugins::Openstack::Action::ReadSSHInfo do
 
   let(:nova) do
     double('nova').tap do |nova|
-      nova.stub(:get_all_floating_ips).with(anything) do
-        [FloatingIP.new('80.81.82.83', 'pool-1', nil), FloatingIP.new('30.31.32.33', 'pool-2', '1234')]
+      nova.stub(:get_server_details).with(env, '1234') do
+        {
+          'addresses' => {
+            'net' => [
+              {
+                'addr' => '80.80.80.80',
+                'OS-EXT-IPS:type' => 'floating'
+              }
+            ]
+          }
+        }
       end
     end
   end
@@ -136,7 +145,19 @@ describe VagrantPlugins::Openstack::Action::ReadSSHInfo do
           config.stub(:floating_ip) { '80.80.80.80' }
           config.stub(:keypair_name) { nil }
           config.stub(:public_key_path) { nil }
-          nova.stub(:get_server_details) { { 'key_name' => 'my_keypair_name' } }
+          nova.stub(:get_server_details) do
+            {
+              'key_name' => 'my_keypair_name',
+              'addresses' => {
+                'net' => [
+                  {
+                    'addr' => '80.80.80.80',
+                    'OS-EXT-IPS:type' => 'floating'
+                  }
+                ]
+              }
+            }
+          end
           expect(nova).to receive(:get_server_details).with(env, '1234')
           @action.read_ssh_info(env).should eq(
             host: '80.80.80.80',


### PR DESCRIPTION
* Implement network preference (fix #194)
* Always read IP from nova even if a specific floating
  IP is set in the provider's attribute 'floating_ip'