### PR TITLE
Create and boot from volume

### DIFF
--- a/source/.rubocop.yml
+++ b/source/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - 'out/**/*'
+    - '**/Vagrantfile'
 
 Style/FileName:
   Enabled: false
@@ -11,18 +12,24 @@ Style/Encoding:
 Style/Documentation:
   Enabled: false
 
-Style/ClassLength:
+Metrics/ClassLength:
   Max: 300
 
-Style/CyclomaticComplexity:
+Metrics/CyclomaticComplexity:
   Severity: warning
   Max: 15
 
-Style/MethodLength:
+Metrics/MethodLength:
   Max: 60
 
-Style/LineLength:
+Metrics/LineLength:
   Max: 150
 
-Style/ParameterLists:
+Metrics/ParameterLists:
   Max: 6
+
+Metrics/AbcSize:
+  Max: 110
+
+Metrics/PerceivedComplexity:
+  Max: 45

--- a/source/Gemfile
+++ b/source/Gemfile
@@ -5,7 +5,7 @@ gemspec
 group :development do
   gem 'vagrant', git: 'https://github.com/mitchellh/vagrant.git', tag: 'v1.6.5'
   gem 'appraisal', '1.0.0'
-  gem 'rubocop', '0.23.0', require: false
+  gem 'rubocop', '0.29.0', require: false
   gem 'coveralls', require: false
 end
 
@@ -14,5 +14,5 @@ group :debug do
 end
 
 group :plugins do
-  gem "vagrant-openstack-provider", path: "."
+  gem 'vagrant-openstack-provider', path: '.'
 end

--- a/source/lib/vagrant-openstack-provider/action.rb
+++ b/source/lib/vagrant-openstack-provider/action.rb
@@ -1,6 +1,9 @@
 require 'pathname'
 
 require 'vagrant/action/builder'
+require 'vagrant-openstack-provider/version_checker'
+
+VagrantPlugins::Openstack.check_version
 
 module VagrantPlugins
   module Openstack

--- a/source/lib/vagrant-openstack-provider/action.rb
+++ b/source/lib/vagrant-openstack-provider/action.rb
@@ -1,9 +1,6 @@
 require 'pathname'
 
 require 'vagrant/action/builder'
-require 'vagrant-openstack-provider/version_checker'
-
-VagrantPlugins::Openstack.check_version
 
 module VagrantPlugins
   module Openstack

--- a/source/lib/vagrant-openstack-provider/action/create_server.rb
+++ b/source/lib/vagrant-openstack-provider/action/create_server.rb
@@ -31,7 +31,7 @@ module VagrantPlugins
 
           options = {
             flavor: @resolver.resolve_flavor(env),
-            image: @resolver.resolve_image(env),
+            image: @resolver.resolve_image(env, config.image),
             volume_boot: @resolver.resolve_volume_boot(env),
             networks: @resolver.resolve_networks(env),
             volumes: @resolver.resolve_volumes(env),

--- a/source/lib/vagrant-openstack-provider/client/domain.rb
+++ b/source/lib/vagrant-openstack-provider/client/domain.rb
@@ -106,7 +106,7 @@ module VagrantPlugins
         #
         attr_accessor :device
 
-        # rubocop:disable Style/ParameterLists
+        # rubocop:disable Metrics/ParameterLists
         def initialize(id, name, size, status, bootable, instance_id, device)
           @size = size
           @status = status
@@ -115,7 +115,7 @@ module VagrantPlugins
           @device = device
           super(id, name)
         end
-        # rubocop:enable Style/ParameterLists
+        # rubocop:enable Metrics/ParameterLists
 
         def to_s
           {

--- a/source/lib/vagrant-openstack-provider/client/nova.rb
+++ b/source/lib/vagrant-openstack-provider/client/nova.rb
@@ -51,7 +51,17 @@ module VagrantPlugins
         server = {}.tap do |s|
           s['name'] = options[:name]
           if options[:image_ref].nil?
-            s['block_device_mapping'] = [{ volume_id: options[:volume_boot][:id], device_name: options[:volume_boot][:device] }]
+            s['block_device_mapping'] = [{ volume_id: options[:volume_boot][:id],
+                                           device_name: options[:volume_boot][:device] }] if options[:volume_boot].key?(:id)
+            # elsif !options[:volume_boot].nil?
+            s['block_device_mapping_v2'] = [{ boot_index: '0',
+                                              volume_size: options[:volume_boot][:size],
+                                              uuid: options[:volume_boot][:image],
+                                              device_name: options[:volume_boot][:device],
+                                              source_type: 'image',
+                                              destination_type: 'volume',
+                                              delete_on_termination: options[:volume_boot][:delete_on_destroy] }]\
+                                              if options[:volume_boot].key?(:image)
           else
             s['imageRef'] = options[:image_ref]
           end

--- a/source/lib/vagrant-openstack-provider/client/nova.rb
+++ b/source/lib/vagrant-openstack-provider/client/nova.rb
@@ -52,8 +52,7 @@ module VagrantPlugins
           s['name'] = options[:name]
           if options[:image_ref].nil?
             s['block_device_mapping'] = [{ volume_id: options[:volume_boot][:id],
-                                           device_name: options[:volume_boot][:device] }] if options[:volume_boot].key?(:id)
-            # elsif !options[:volume_boot].nil?
+                                           device_name: options[:volume_boot][:device] }] unless options[:volume_boot][:id].nil?
             s['block_device_mapping_v2'] = [{ boot_index: '0',
                                               volume_size: options[:volume_boot][:size],
                                               uuid: options[:volume_boot][:image],
@@ -61,7 +60,7 @@ module VagrantPlugins
                                               source_type: 'image',
                                               destination_type: 'volume',
                                               delete_on_termination: options[:volume_boot][:delete_on_destroy] }]\
-                                              if options[:volume_boot].key?(:image)
+                                              unless options[:volume_boot][:image].nil?
           else
             s['imageRef'] = options[:image_ref]
           end

--- a/source/lib/vagrant-openstack-provider/command/main.rb
+++ b/source/lib/vagrant-openstack-provider/command/main.rb
@@ -2,7 +2,7 @@ module VagrantPlugins
   module Openstack
     module Command
       COMMANDS = [
-        { name: :'image-list', file: 'image_list' , clazz: 'ImageList' },
+        { name: :'image-list', file: 'image_list', clazz: 'ImageList' },
         { name: :'flavor-list', file: 'flavor_list', clazz: 'FlavorList' },
         { name: :'network-list', file: 'network_list', clazz: 'NetworkList' },
         { name: :'subnet-list', file: 'subnet_list', clazz: 'SubnetList' },

--- a/source/lib/vagrant-openstack-provider/command/main.rb
+++ b/source/lib/vagrant-openstack-provider/command/main.rb
@@ -1,7 +1,3 @@
-require 'vagrant-openstack-provider/version_checker'
-
-VagrantPlugins::Openstack.check_version
-
 module VagrantPlugins
   module Openstack
     module Command

--- a/source/lib/vagrant-openstack-provider/command/main.rb
+++ b/source/lib/vagrant-openstack-provider/command/main.rb
@@ -13,7 +13,6 @@ module VagrantPlugins
 
       class Main < Vagrant.plugin('2', :command)
         def self.synopsis
-          Openstack.init_i18n
           I18n.t('vagrant_openstack.command.main_synopsis')
         end
 
@@ -33,7 +32,6 @@ module VagrantPlugins
         end
 
         def execute
-          Openstack.init_i18n
           command_class = @commands.get(@sub_command.to_sym) if @sub_command
           return usage unless command_class && @sub_command
           command_class.new(@sub_args, @env).execute(@sub_command)

--- a/source/lib/vagrant-openstack-provider/command/main.rb
+++ b/source/lib/vagrant-openstack-provider/command/main.rb
@@ -1,3 +1,7 @@
+require 'vagrant-openstack-provider/version_checker'
+
+VagrantPlugins::Openstack.check_version
+
 module VagrantPlugins
   module Openstack
     module Command

--- a/source/lib/vagrant-openstack-provider/config.rb
+++ b/source/lib/vagrant-openstack-provider/config.rb
@@ -276,7 +276,7 @@ module VagrantPlugins
         result
       end
 
-      # rubocop:disable Style/CyclomaticComplexity
+      # rubocop:disable Metrics/CyclomaticComplexity
       def finalize!
         @password = nil if @password == UNSET_VALUE
         @openstack_compute_url = nil if @openstack_compute_url == UNSET_VALUE
@@ -323,7 +323,7 @@ module VagrantPlugins
         @stacks = nil if @stacks.empty?
         @http.finalize!
       end
-      # rubocop:enable Style/CyclomaticComplexity
+      # rubocop:enable Metrics/CyclomaticComplexity
 
       def rsync_include(inc)
         @rsync_includes << inc

--- a/source/lib/vagrant-openstack-provider/config_resolver.rb
+++ b/source/lib/vagrant-openstack-provider/config_resolver.rb
@@ -65,7 +65,7 @@ module VagrantPlugins
         return resolve_networks_without_network_service(env) unless env[:openstack_client].session.endpoints.key? :network
 
         all_networks = env[:openstack_client].neutron.get_all_networks(env)
-        all_network_ids = all_networks.map { |v| v.id }
+        all_network_ids = all_networks.map(&:id)
 
         networks = []
         config.networks.each do |network|
@@ -82,7 +82,7 @@ module VagrantPlugins
         return resolve_volume_without_volume_service(env, config.volume_boot, 'vda') unless env[:openstack_client].session.endpoints.key? :volume
 
         volume_list = env[:openstack_client].cinder.get_all_volumes(env)
-        volume_ids = volume_list.map { |v| v.id }
+        volume_ids = volume_list.map(&:id)
 
         @logger.debug(volume_list)
 
@@ -100,7 +100,7 @@ module VagrantPlugins
         return resolve_volumes_without_volume_service(env) unless env[:openstack_client].session.endpoints.key? :volume
 
         volume_list = env[:openstack_client].cinder.get_all_volumes(env)
-        volume_ids = volume_list.map { |v| v.id }
+        volume_ids = volume_list.map(&:id)
 
         @logger.debug(volume_list)
 

--- a/source/lib/vagrant-openstack-provider/errors.rb
+++ b/source/lib/vagrant-openstack-provider/errors.rb
@@ -51,6 +51,10 @@ module VagrantPlugins
         error_key(:no_matching_image)
       end
 
+      class ConflictImageName < VagrantOpenstackError
+        error_key(:conflict_image_name)
+      end
+
       class SyncMethodError < VagrantOpenstackError
         error_key(:sync_method_error)
       end

--- a/source/lib/vagrant-openstack-provider/plugin.rb
+++ b/source/lib/vagrant-openstack-provider/plugin.rb
@@ -4,6 +4,8 @@ rescue LoadError
   raise 'The Openstack Cloud provider must be run within Vagrant.'
 end
 
+require 'vagrant-openstack-provider/version_checker'
+
 # This is a sanity check to make sure no one is attempting to install
 # this into an early Vagrant version.
 if Vagrant::VERSION < '1.4.0'
@@ -27,6 +29,7 @@ module VagrantPlugins
         # Setup some things
         Openstack.init_i18n
         Openstack.init_logging
+        VagrantPlugins::Openstack.check_version
 
         # Load the actual provider
         require_relative 'provider'
@@ -34,6 +37,8 @@ module VagrantPlugins
       end
 
       command('openstack') do
+        VagrantPlugins::Openstack.check_version
+
         require_relative 'command/main'
         Command::Main
       end

--- a/source/lib/vagrant-openstack-provider/plugin.rb
+++ b/source/lib/vagrant-openstack-provider/plugin.rb
@@ -26,7 +26,6 @@ module VagrantPlugins
       end
 
       provider(:openstack, box_optional: true) do
-        # Setup some things
         Openstack.init_i18n
         Openstack.init_logging
         VagrantPlugins::Openstack.check_version
@@ -37,6 +36,8 @@ module VagrantPlugins
       end
 
       command('openstack') do
+        Openstack.init_i18n
+        Openstack.init_logging
         VagrantPlugins::Openstack.check_version
 
         require_relative 'command/main'

--- a/source/lib/vagrant-openstack-provider/version.rb
+++ b/source/lib/vagrant-openstack-provider/version.rb
@@ -1,5 +1,15 @@
 module VagrantPlugins
   module Openstack
+    #
+    # Stable versions must respect the pattern given
+    # by VagrantPlugins::Openstack::VERSION_PATTERN
+    #
     VERSION = '0.6.1'
+
+    #
+    # Stable version must respect the naming convention 'x.y.z'
+    # where x, y and z are integers inside the range [0, 999]
+    #
+    VERSION_PATTERN = /^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$/
   end
 end

--- a/source/lib/vagrant-openstack-provider/version_checker.rb
+++ b/source/lib/vagrant-openstack-provider/version_checker.rb
@@ -1,0 +1,74 @@
+require 'colorize'
+require 'singleton'
+require 'vagrant-openstack-provider/version'
+
+module VagrantPlugins
+  module Openstack
+    class VersionChecker
+      include Singleton
+
+      #
+      # :latest, :outdated or :unstable
+      #
+      # A version is considered unstable if it does not
+      # respect the pattern or if it is greater than the
+      # latest from rubygem
+      #
+      attr_accessor :status
+
+      def initialize
+        @status = nil
+      end
+
+      #
+      # Check the latest version from rubygem and set the status
+      #
+      def check
+        return @status unless @status.nil?
+        latest  = Gem.latest_spec_for('vagrant-openstack-provider').version.version
+        current = VagrantPlugins::Openstack::VERSION
+
+        unless current =~ VERSION_PATTERN
+          @status = :unstable
+          print I18n.t('vagrant_openstack.version_unstable')
+          return
+        end
+
+        if latest.eql? current
+          @status = :latest
+          return
+        end
+
+        v_latest = latest.split('.').map(&:to_i)
+        v_current = current.split('.').map(&:to_i)
+
+        i_latest = v_latest[2] + v_latest[1] * 1000 + v_latest[0] * 1_000_000
+        i_current = v_current[2] + v_current[1] * 1000 + v_current[0] * 1_000_000
+
+        if i_current > i_latest
+          @status = :unstable
+          print I18n.t('vagrant_openstack.version_unstable')
+          return
+        end
+
+        @status = :outdated
+        print I18n.t('vagrant_openstack.version_outdated', latest: latest, current: current)
+      end
+
+      private
+
+      def print(message)
+        puts message.yellow
+        puts ''
+      end
+    end
+
+    # rubocop:disable Lint/HandleExceptions
+    def self.check_version
+      VersionChecker.instance.check
+    rescue
+      # Do nothing whatever the failure cause
+    end
+    # rubocop:enable Lint/HandleExceptions
+  end
+end

--- a/source/lib/vagrant-openstack-provider/version_checker.rb
+++ b/source/lib/vagrant-openstack-provider/version_checker.rb
@@ -65,7 +65,9 @@ module VagrantPlugins
 
     # rubocop:disable Lint/HandleExceptions
     def self.check_version
-      VersionChecker.instance.check
+      timeout(3, Errors::Timeout) do
+        VersionChecker.instance.check
+      end
     rescue
       # Do nothing whatever the failure cause
     end

--- a/source/locales/en.yml
+++ b/source/locales/en.yml
@@ -167,6 +167,9 @@ en:
       no_matching_image: |-
         No matching image was found! Please check your image setting to
         make sure you have a valid image chosen.
+      conflict_image_name: |-
+        One (and only one) image must be specified in the configuration.
+        Please check that an image name is not defined also in the 'volume_boot' definition.
       sync_method_error: |-
         Value '%{sync_method_value}' is not allowed for 'sync_method' configuration parameter. Valid values are 'rsync' and 'none'
       rsync_error: |-

--- a/source/locales/en.yml
+++ b/source/locales/en.yml
@@ -15,6 +15,20 @@ en:
 
       We are looking for feedback, so feel free to ask questions or
       describe features you would like to see in this provider.
+    version_outdated: |-
+      You're not using the latest version of the 'vagrant-openstack-provider' plugin.
+      The latest version is %{latest}, yours is %{current}. You should update to the latest
+      version running the command :
+
+          $ vagrant plugin update vagrant-openstack-provider
+    version_unstable: |-
+      You're not running a stable version of the 'vagrant-openstack-provider' plugin.
+      Unless you are either developing on vagrant or have deliberatly installed a not
+      stable version, you should uninstall it an install the latest stable version
+      running commands :
+
+          $ vagrant plugin uninstall vagrant-openstack-provider
+          $ vagrant plugin install vagrant-openstack-provider
     already_created: |-
       The server is already created.
     create_stack: |-

--- a/source/spec/vagrant-openstack-provider/action/connect_openstack_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/connect_openstack_spec.rb
@@ -4,7 +4,6 @@ include VagrantPlugins::Openstack::Action
 include VagrantPlugins::Openstack::HttpUtils
 
 describe VagrantPlugins::Openstack::Action::ConnectOpenstack do
-
   let(:app) do
     double.tap do |app|
       app.stub(:call)
@@ -160,7 +159,7 @@ describe VagrantPlugins::Openstack::Action::ConnectOpenstack do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:ui] = double
       env[:ui].stub(:info).with(anything)
       env[:ui].stub(:warn).with(anything)
@@ -309,9 +308,9 @@ describe VagrantPlugins::Openstack::Action::ConnectOpenstack do
         @action.call(env)
 
         expect(env[:openstack_client].session.endpoints)
-        .to eq(compute: 'http://france.nova/v2/projectId',
-               network: 'http://france.neutron/v2.0',
-               image:   'http://france.glance/v2.0')
+          .to eq(compute: 'http://france.nova/v2/projectId',
+                 network: 'http://france.neutron/v2.0',
+                 image:   'http://france.glance/v2.0')
       end
     end
 
@@ -417,10 +416,10 @@ describe VagrantPlugins::Openstack::Action::ConnectOpenstack do
           @action.call(env)
 
           expect(env[:openstack_client].session.endpoints)
-          .to eq(compute: 'http://nova/v2/projectId/admin',
-                 network: 'http://neutron/v2.0/admin',
-                 volume:  'http://cinder/v2/projectId/admin',
-                 image:   'http://glance/v2.0/admin')
+            .to eq(compute: 'http://nova/v2/projectId/admin',
+                   network: 'http://neutron/v2.0/admin',
+                   volume:  'http://cinder/v2/projectId/admin',
+                   image:   'http://glance/v2.0/admin')
         end
       end
     end
@@ -464,8 +463,8 @@ describe VagrantPlugins::Openstack::Action::ConnectOpenstack do
           @action.call(env)
 
           expect(env[:openstack_client].session.endpoints)
-          .to eq(compute: 'http://nova/v2/projectId/internal',
-                 volume:  'http://cinder/v2/projectId/internal')
+            .to eq(compute: 'http://nova/v2/projectId/internal',
+                   volume:  'http://cinder/v2/projectId/internal')
         end
       end
     end
@@ -531,10 +530,10 @@ describe VagrantPlugins::Openstack::Action::ConnectOpenstack do
           @action.call(env)
 
           expect(env[:openstack_client].session.endpoints)
-          .to eq(compute: 'http://nova/v2/projectId',
-                 network: 'http://neutron/v2.0',
-                 volume:  'http://cinder/v2/projectId',
-                 image:   'http://glance/v2.0')
+            .to eq(compute: 'http://nova/v2/projectId',
+                   network: 'http://neutron/v2.0',
+                   volume:  'http://cinder/v2/projectId',
+                   image:   'http://glance/v2.0')
         end
       end
     end
@@ -573,8 +572,8 @@ describe VagrantPlugins::Openstack::Action::ConnectOpenstack do
         @action.call(env)
 
         expect(env[:openstack_client].session.endpoints)
-        .to eq(compute: 'http://nova/v2/projectId',
-               image:   'http://glance/v1')
+          .to eq(compute: 'http://nova/v2/projectId',
+                 image:   'http://glance/v1')
       end
     end
 
@@ -603,7 +602,6 @@ describe VagrantPlugins::Openstack::Action::ConnectOpenstack do
     end
 
     context 'with no matching versions for network service' do
-
       let(:neutron) do
         double.tap do |neutron|
           neutron.stub(:get_api_version_list).with(anything, anything) do
@@ -690,7 +688,7 @@ describe VagrantPlugins::Openstack::Action::ConnectOpenstack do
         @action.call(env)
 
         expect(env[:openstack_client].session.endpoints)
-        .to eq(compute: 'http://nova/v2/projectId', identity: 'http://keystone/v2.0')
+          .to eq(compute: 'http://nova/v2/projectId', identity: 'http://keystone/v2.0')
       end
     end
   end

--- a/source/spec/vagrant-openstack-provider/action/create_server_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/create_server_spec.rb
@@ -58,7 +58,7 @@ describe VagrantPlugins::Openstack::Action::CreateServer do
       r.stub(:resolve_flavor).with(anything) do
         Flavor.new('flavor-01', 'small', nil, nil, nil)
       end
-      r.stub(:resolve_image).with(anything) do
+      r.stub(:resolve_image).with(anything, anything) do
         Item.new('image-01', 'ubuntu')
       end
       r.stub(:resolve_volume_boot).with(anything) { 'ubuntu-drive' }

--- a/source/spec/vagrant-openstack-provider/action/create_server_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/create_server_spec.rb
@@ -7,7 +7,6 @@ include VagrantPlugins::Openstack::HttpUtils
 include VagrantPlugins::Openstack::Domain
 
 describe VagrantPlugins::Openstack::Action::CreateServer do
-
   let(:config) do
     double('config').tap do |config|
       config.stub(:tenant_name) { 'testTenant' }
@@ -41,7 +40,7 @@ describe VagrantPlugins::Openstack::Action::CreateServer do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:ui] = double('ui')
       env[:ui].stub(:info).with(anything)
       env[:machine] = double('machine')
@@ -124,18 +123,19 @@ describe VagrantPlugins::Openstack::Action::CreateServer do
     context 'with all options specified' do
       it 'calls nova with all the options' do
         nova.stub(:create_server).with(
-        env,
-        name: 'testName',
-        flavor_ref: flavor.id,
-        image_ref: image.id,
-        volume_boot: nil,
-        networks: [{ uuid: 'test-networks-1' }, { uuid: 'test-networks-2', fixed_ip: '1.2.3.4' }],
-        keypair: 'test-keypair',
-        availability_zone: 'test-az',
-        scheduler_hints: 'test-sched-hints',
-        security_groups: ['test-sec-groups'],
-        user_data: 'test-user_data',
-        metadata: 'test-metadata') do '1234'
+          env,
+          name: 'testName',
+          flavor_ref: flavor.id,
+          image_ref: image.id,
+          volume_boot: nil,
+          networks: [{ uuid: 'test-networks-1' }, { uuid: 'test-networks-2', fixed_ip: '1.2.3.4' }],
+          keypair: 'test-keypair',
+          availability_zone: 'test-az',
+          scheduler_hints: 'test-sched-hints',
+          security_groups: ['test-sec-groups'],
+          user_data: 'test-user_data',
+          metadata: 'test-metadata') do
+          '1234'
         end
 
         options = {
@@ -169,7 +169,8 @@ describe VagrantPlugins::Openstack::Action::CreateServer do
           scheduler_hints: nil,
           security_groups: [],
           user_data: nil,
-          metadata: nil) do '1234'
+          metadata: nil) do
+          '1234'
         end
 
         options = {
@@ -193,19 +194,19 @@ describe VagrantPlugins::Openstack::Action::CreateServer do
   describe 'waiting_for_server_to_be_built' do
     context 'when server is not yet active' do
       it 'become active after one retry' do
-        nova.stub(:get_server_details).and_return({ 'status' => 'BUILD' }, { 'status' => 'ACTIVE' })
+        nova.stub(:get_server_details).and_return({ 'status' => 'BUILD' }, 'status' => 'ACTIVE')
         nova.should_receive(:get_server_details).with(env, 'server-01').exactly(2).times
         config.stub(:server_create_timeout) { 5 }
         @action.waiting_for_server_to_be_built(env, 'server-01', 1)
       end
       it 'timeout before the server become active' do
-        nova.stub(:get_server_details).and_return({ 'status' => 'BUILD' }, { 'status' => 'BUILD' })
+        nova.stub(:get_server_details).and_return({ 'status' => 'BUILD' }, 'status' => 'BUILD')
         nova.should_receive(:get_server_details).with(env, 'server-01').at_least(2).times
         config.stub(:server_create_timeout) { 3 }
         expect { @action.waiting_for_server_to_be_built(env, 'server-01', 1) }.to raise_error Errors::Timeout
       end
       it 'raise an error after one retry' do
-        nova.stub(:get_server_details).and_return({ 'status' => 'BUILD' }, { 'status' => 'ERROR' })
+        nova.stub(:get_server_details).and_return({ 'status' => 'BUILD' }, 'status' => 'ERROR')
         nova.should_receive(:get_server_details).with(env, 'server-01').exactly(2).times
         config.stub(:server_create_timeout) { 3 }
         expect { @action.waiting_for_server_to_be_built(env, 'server-01', 1) }.to raise_error Errors::ServerStatusError

--- a/source/spec/vagrant-openstack-provider/action/create_stack_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/create_stack_spec.rb
@@ -7,7 +7,6 @@ include VagrantPlugins::Openstack::HttpUtils
 include VagrantPlugins::Openstack::Domain
 
 describe VagrantPlugins::Openstack::Action::CreateStack do
-
   let(:config) do
     double('config').tap do |config|
       config.stub(:stacks) do
@@ -31,7 +30,7 @@ describe VagrantPlugins::Openstack::Action::CreateStack do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:ui] = double('ui')
       env[:ui].stub(:info).with(anything)
       env[:machine] = double('machine')
@@ -61,7 +60,6 @@ describe VagrantPlugins::Openstack::Action::CreateStack do
             image: CoreOS
             flavor: 1_vCPU_RAM_512M_HD_10G
     '))
-
   end
 
   describe 'call' do
@@ -79,19 +77,19 @@ describe VagrantPlugins::Openstack::Action::CreateStack do
   describe 'waiting_for_server_to_be_built' do
     context 'when server is not yet active' do
       it 'become active after one retry' do
-        heat.stub(:get_stack_details).and_return({ 'stack_status' => 'CREATE_IN_PROGRESS' }, { 'stack_status' => 'CREATE_COMPLETE' })
+        heat.stub(:get_stack_details).and_return({ 'stack_status' => 'CREATE_IN_PROGRESS' }, 'stack_status' => 'CREATE_COMPLETE')
         heat.should_receive(:get_stack_details).with(env, 'stack1', 'id-01').exactly(2).times
         config.stub(:stack_create_timeout) { 5 }
         @action.waiting_for_stack_to_be_created(env, 'stack1', 'id-01', 1)
       end
       it 'timeout before the server become active' do
-        heat.stub(:get_stack_details).and_return({ 'stack_status' => 'CREATE_IN_PROGRESS' }, { 'stack_status' => 'CREATE_IN_PROGRESS' })
+        heat.stub(:get_stack_details).and_return({ 'stack_status' => 'CREATE_IN_PROGRESS' }, 'stack_status' => 'CREATE_IN_PROGRESS')
         heat.should_receive(:get_stack_details).with(env, 'stack1', 'id-01').at_least(2).times
         config.stub(:stack_create_timeout) { 3 }
         expect { @action.waiting_for_stack_to_be_created(env, 'stack1', 'id-01', 1) }.to raise_error Errors::Timeout
       end
       it 'raise an error after one retry' do
-        heat.stub(:get_stack_details).and_return({ 'stack_status' => 'CREATE_IN_PROGRESS' }, { 'stack_status' => 'CREATE_FAILED' })
+        heat.stub(:get_stack_details).and_return({ 'stack_status' => 'CREATE_IN_PROGRESS' }, 'stack_status' => 'CREATE_FAILED')
         heat.should_receive(:get_stack_details).with(env, 'stack1', 'id-01').exactly(2).times
         config.stub(:stack_create_timeout) { 3 }
         expect { @action.waiting_for_stack_to_be_created(env, 'stack1', 'id-01', 1) }.to raise_error Errors::StackStatusError

--- a/source/spec/vagrant-openstack-provider/action/delete_server_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/delete_server_spec.rb
@@ -1,7 +1,6 @@
 require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::Action::DeleteServer do
-
   let(:nova) do
     double('nova').tap do |app|
       app.stub(:delete_server)
@@ -20,7 +19,7 @@ describe VagrantPlugins::Openstack::Action::DeleteServer do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:ui] = double('ui')
       env[:ui].stub(:info).with(anything)
       env[:ui].stub(:error).with(anything)
@@ -68,24 +67,23 @@ describe VagrantPlugins::Openstack::Action::DeleteServer do
         @action.waiting_for_instance_to_be_deleted(env, 'server-01', 1)
       end
       it 'become deleted after one retry' do
-        nova.stub(:get_server_details).and_return({ 'status' => 'ACTIVE' }, { 'status' => 'DELETED' })
+        nova.stub(:get_server_details).and_return({ 'status' => 'ACTIVE' }, 'status' => 'DELETED')
         nova.should_receive(:get_server_details).with(env, 'server-01').exactly(2).times
         config.stub(:server_delete_timeout) { 5 }
         @action.waiting_for_instance_to_be_deleted(env, 'server-01', 1)
       end
       it 'timeout before the server become active' do
-        nova.stub(:get_server_details).and_return({ 'status' => 'ACTIVE' }, { 'status' => 'ACTIVE' })
+        nova.stub(:get_server_details).and_return({ 'status' => 'ACTIVE' }, 'status' => 'ACTIVE')
         nova.should_receive(:get_server_details).with(env, 'server-01').at_least(2).times
         config.stub(:server_delete_timeout) { 3 }
         expect { @action.waiting_for_instance_to_be_deleted(env, 'server-01', 1) }.to raise_error Errors::Timeout
       end
       it 'raise an error after one retry' do
-        nova.stub(:get_server_details).and_return({ 'status' => 'ACTIVE' }, { 'status' => 'ERROR' })
+        nova.stub(:get_server_details).and_return({ 'status' => 'ACTIVE' }, 'status' => 'ERROR')
         nova.should_receive(:get_server_details).with(env, 'server-01').exactly(2).times
         config.stub(:server_delete_timeout) { 3 }
         expect { @action.waiting_for_instance_to_be_deleted(env, 'server-01', 1) }.to raise_error Errors::ServerStatusError
       end
     end
   end
-
 end

--- a/source/spec/vagrant-openstack-provider/action/delete_stack_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/delete_stack_spec.rb
@@ -1,7 +1,6 @@
 require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::Action::DeleteStack do
-
   let(:heat) do
     double('heat').tap do |app|
       app.stub(:delete_stack)
@@ -15,7 +14,7 @@ describe VagrantPlugins::Openstack::Action::DeleteStack do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:ui] = double('ui')
       env[:ui].stub(:info).with(anything)
       env[:ui].stub(:error).with(anything)

--- a/source/spec/vagrant-openstack-provider/action/message_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/message_spec.rb
@@ -1,7 +1,6 @@
 require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::Action::Message do
-
   let(:ui) do
     double('ui').tap do |ui|
       ui.stub(:info).with(anything)
@@ -10,7 +9,7 @@ describe VagrantPlugins::Openstack::Action::Message do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:ui] = ui
     end
   end

--- a/source/spec/vagrant-openstack-provider/action/read_ssh_info_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/read_ssh_info_spec.rb
@@ -5,7 +5,6 @@ include VagrantPlugins::Openstack::HttpUtils
 include VagrantPlugins::Openstack::Domain
 
 describe VagrantPlugins::Openstack::Action::ReadSSHInfo do
-
   let(:config) do
     double('config').tap do |config|
       config.stub(:openstack_auth_url) { 'http://keystoneAuthV2' }
@@ -54,7 +53,7 @@ describe VagrantPlugins::Openstack::Action::ReadSSHInfo do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:ui] = double('ui')
       env[:ui].stub(:info).with(anything)
       env[:machine] = double('machine')
@@ -188,5 +187,4 @@ describe VagrantPlugins::Openstack::Action::ReadSSHInfo do
       end
     end
   end
-
 end

--- a/source/spec/vagrant-openstack-provider/action/read_state_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/read_state_spec.rb
@@ -1,13 +1,12 @@
 require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::Action::ReadState do
-
   let(:nova) do
     double('nova')
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:ui] = double('ui').tap do |ui|
         ui.stub(:info).with(anything)
         ui.stub(:error).with(anything)

--- a/source/spec/vagrant-openstack-provider/action/resume_server_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/resume_server_spec.rb
@@ -1,7 +1,6 @@
 require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::Action::Resume do
-
   let(:nova) do
     double('nova').tap do |nova|
       nova.stub(:resume_server)
@@ -9,7 +8,7 @@ describe VagrantPlugins::Openstack::Action::Resume do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:ui] = double('ui').tap do |ui|
         ui.stub(:info).with(anything)
         ui.stub(:error).with(anything)

--- a/source/spec/vagrant-openstack-provider/action/start_server_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/start_server_spec.rb
@@ -1,7 +1,6 @@
 require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::Action::StartServer do
-
   let(:nova) do
     double('nova').tap do |nova|
       nova.stub(:start_server)
@@ -9,7 +8,7 @@ describe VagrantPlugins::Openstack::Action::StartServer do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:ui] = double('ui').tap do |ui|
         ui.stub(:info).with(anything)
         ui.stub(:error).with(anything)

--- a/source/spec/vagrant-openstack-provider/action/stop_server_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/stop_server_spec.rb
@@ -1,7 +1,6 @@
 require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::Action::StopServer do
-
   let(:nova) do
     double('nova').tap do |nova|
       nova.stub(:stop_server)
@@ -9,7 +8,7 @@ describe VagrantPlugins::Openstack::Action::StopServer do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:ui] = double('ui').tap do |ui|
         ui.stub(:info).with(anything)
         ui.stub(:error).with(anything)

--- a/source/spec/vagrant-openstack-provider/action/suspend_server_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/suspend_server_spec.rb
@@ -1,7 +1,6 @@
 require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::Action::Suspend do
-
   let(:nova) do
     double('nova').tap do |nova|
       nova.stub(:suspend_server)
@@ -9,7 +8,7 @@ describe VagrantPlugins::Openstack::Action::Suspend do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:ui] = double('ui').tap do |ui|
         ui.stub(:info).with(anything)
         ui.stub(:error).with(anything)

--- a/source/spec/vagrant-openstack-provider/action/sync_folders_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/sync_folders_spec.rb
@@ -6,7 +6,6 @@ require 'vagrant/util/subprocess'
 include VagrantPlugins::Openstack::Action
 
 describe VagrantPlugins::Openstack::Action::SyncFolders do
-
   let(:app) do
     double('app').tap do |app|
       app.stub(:call).with(anything)
@@ -34,7 +33,7 @@ describe VagrantPlugins::Openstack::Action::SyncFolders do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:ui] = double('ui').tap do |ui|
         ui.stub(:info).with(anything)
         ui.stub(:error).with(anything)

--- a/source/spec/vagrant-openstack-provider/action/wait_accessible_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/wait_accessible_spec.rb
@@ -1,13 +1,12 @@
 require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::Action::WaitForServerToBeAccessible do
-
   let(:config) do
     double('config')
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:ui] = double('ui')
       env[:ui].stub(:info).with(anything)
       env[:ui].stub(:error).with(anything)

--- a/source/spec/vagrant-openstack-provider/action/wait_active_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/wait_active_spec.rb
@@ -1,7 +1,6 @@
 require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::Action::WaitForServerToBeActive do
-
   let(:nova) do
     double('nova')
   end
@@ -11,7 +10,7 @@ describe VagrantPlugins::Openstack::Action::WaitForServerToBeActive do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:ui] = double('ui').tap do |ui|
         ui.stub(:info).with(anything)
         ui.stub(:error).with(anything)
@@ -35,7 +34,7 @@ describe VagrantPlugins::Openstack::Action::WaitForServerToBeActive do
   describe 'call' do
     context 'when server is not yet active' do
       it 'become active after one retry' do
-        nova.stub(:get_server_details).and_return({ 'status' => 'BUILD' }, { 'status' => 'ACTIVE' })
+        nova.stub(:get_server_details).and_return({ 'status' => 'BUILD' }, 'status' => 'ACTIVE')
         expect(nova).to receive(:get_server_details).with(env, 'server_id').exactly(2).times
         expect(app).to receive(:call)
         config.stub(:server_active_timeout) { 5 }
@@ -43,7 +42,7 @@ describe VagrantPlugins::Openstack::Action::WaitForServerToBeActive do
         @action.call(env)
       end
       it 'timeout after one retry' do
-        nova.stub(:get_server_details).and_return({ 'status' => 'BUILD' }, { 'status' => 'BUILD' })
+        nova.stub(:get_server_details).and_return({ 'status' => 'BUILD' }, 'status' => 'BUILD')
         expect(nova).to receive(:get_server_details).with(env, 'server_id').at_least(2).times
         config.stub(:server_active_timeout) { 2 }
         @action = WaitForServerToBeActive.new(app, nil, 1)

--- a/source/spec/vagrant-openstack-provider/action/wait_stop_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/wait_stop_spec.rb
@@ -1,7 +1,6 @@
 require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::Action::WaitForServerToStop do
-
   let(:nova) do
     double('nova')
   end
@@ -11,7 +10,7 @@ describe VagrantPlugins::Openstack::Action::WaitForServerToStop do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:ui] = double('ui').tap do |ui|
         ui.stub(:info).with(anything)
         ui.stub(:error).with(anything)
@@ -35,7 +34,7 @@ describe VagrantPlugins::Openstack::Action::WaitForServerToStop do
   describe 'call' do
     context 'when server is active' do
       it 'become shutoff after one retry' do
-        nova.stub(:get_server_details).and_return({ 'status' => 'ACTIVE' }, { 'status' => 'SHUTOFF' })
+        nova.stub(:get_server_details).and_return({ 'status' => 'ACTIVE' }, 'status' => 'SHUTOFF')
         expect(nova).to receive(:get_server_details).with(env, 'server_id').exactly(2).times
         expect(app).to receive(:call)
         config.stub(:server_stop_timeout) { 5 }
@@ -43,7 +42,7 @@ describe VagrantPlugins::Openstack::Action::WaitForServerToStop do
         @action.call(env)
       end
       it 'timeout after one retry' do
-        nova.stub(:get_server_details).and_return({ 'status' => 'ACTIVE' }, { 'status' => 'ACTIVE' })
+        nova.stub(:get_server_details).and_return({ 'status' => 'ACTIVE' }, 'status' => 'ACTIVE')
         expect(nova).to receive(:get_server_details).with(env, 'server_id').at_least(2).times
         config.stub(:server_stop_timeout) { 2 }
         @action = WaitForServerToStop.new(app, nil, 1)

--- a/source/spec/vagrant-openstack-provider/action_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action_spec.rb
@@ -1,7 +1,6 @@
 require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::Action do
-
   let(:builder) do
     double('builder').tap do |builder|
       builder.stub(:use)

--- a/source/spec/vagrant-openstack-provider/client/cinder_spec.rb
+++ b/source/spec/vagrant-openstack-provider/client/cinder_spec.rb
@@ -1,7 +1,6 @@
 require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::CinderClient do
-
   let(:http) do
     double('http').tap do |http|
       http.stub(:read_timeout) { 42 }
@@ -16,7 +15,7 @@ describe VagrantPlugins::Openstack::CinderClient do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:machine] = double('machine')
       env[:machine].stub(:provider_config) { config }
     end
@@ -36,15 +35,14 @@ describe VagrantPlugins::Openstack::CinderClient do
   describe 'get_all_volumes' do
     context 'on api v1' do
       it 'returns volumes with details' do
-
         stub_request(:get, 'http://cinder/volumes/detail')
-        .with(
+          .with(
             headers:
                 {
                   'Accept' => 'application/json',
                   'X-Auth-Token' => '123456'
                 })
-        .to_return(
+          .to_return(
             status: 200,
             body: '
                 {
@@ -83,15 +81,14 @@ describe VagrantPlugins::Openstack::CinderClient do
 
     context 'on api v2' do
       it 'returns volumes with details' do
-
         stub_request(:get, 'http://cinder/volumes/detail')
-        .with(
+          .with(
             headers:
                 {
                   'Accept' => 'application/json',
                   'X-Auth-Token' => '123456'
                 })
-        .to_return(
+          .to_return(
             status: 200,
             body: '
                 {

--- a/source/spec/vagrant-openstack-provider/client/glance_spec.rb
+++ b/source/spec/vagrant-openstack-provider/client/glance_spec.rb
@@ -1,7 +1,6 @@
 require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::GlanceClient do
-
   let(:http) do
     double('http').tap do |http|
       http.stub(:read_timeout) { 42 }
@@ -16,7 +15,7 @@ describe VagrantPlugins::Openstack::GlanceClient do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:machine] = double('machine')
       env[:machine].stub(:provider_config) { config }
     end
@@ -38,21 +37,21 @@ describe VagrantPlugins::Openstack::GlanceClient do
       context 'and api version is v2' do
         it 'returns all images with details' do
           stub_request(:get, 'http://glance/images')
-          .with(
-            headers:
+            .with(
+              headers:
+                {
+                  'Accept' => 'application/json',
+                  'X-Auth-Token' => '123456'
+                })
+            .to_return(
+              status: 200,
+              body: '
               {
-                'Accept' => 'application/json',
-                'X-Auth-Token' => '123456'
-              })
-          .to_return(
-            status: 200,
-            body: '
-            {
-              "images": [
-                { "id": "i1", "name": "image1", "visibility": "public",  "size": "1024", "min_ram": "1", "min_disk": "10" },
-                { "id": "i2", "name": "image2", "visibility": "private", "size": "2048", "min_ram": "2", "min_disk": "20" }
-              ]
-            }')
+                "images": [
+                  { "id": "i1", "name": "image1", "visibility": "public",  "size": "1024", "min_ram": "1", "min_disk": "10" },
+                  { "id": "i2", "name": "image2", "visibility": "private", "size": "2048", "min_ram": "2", "min_disk": "20" }
+                ]
+              }')
 
           images = @glance_client.get_all_images(env)
 
@@ -64,38 +63,38 @@ describe VagrantPlugins::Openstack::GlanceClient do
       context 'and api version is v1' do
         it 'returns all images with details' do
           stub_request(:get, 'http://glance/images')
-          .with(
-            headers:
+            .with(
+              headers:
+                {
+                  'Accept' => 'application/json',
+                  'X-Auth-Token' => '123456'
+                })
+            .to_return(
+              status: 200,
+              body: '
               {
-                'Accept' => 'application/json',
-                'X-Auth-Token' => '123456'
-              })
-          .to_return(
-            status: 200,
-            body: '
-            {
-              "images": [
-                { "id": "i1", "name": "image1", "is_public": true  },
-                { "id": "i2", "name": "image2", "is_public": false }
-              ]
-            }')
+                "images": [
+                  { "id": "i1", "name": "image1", "is_public": true  },
+                  { "id": "i2", "name": "image2", "is_public": false }
+                ]
+              }')
 
           stub_request(:get, 'http://glance/images/detail')
-          .with(
-            headers:
+            .with(
+              headers:
+                {
+                  'Accept' => 'application/json',
+                  'X-Auth-Token' => '123456'
+                })
+            .to_return(
+              status: 200,
+              body: '
               {
-                'Accept' => 'application/json',
-                'X-Auth-Token' => '123456'
-              })
-          .to_return(
-            status: 200,
-            body: '
-            {
-              "images": [
-                { "id": "i1", "name": "image1", "is_public": true,  "size": "1024", "min_ram": "1", "min_disk": "10" },
-                { "id": "i2", "name": "image2", "is_public": false, "size": "2048", "min_ram": "2", "min_disk": "20" }
-              ]
-            }')
+                "images": [
+                  { "id": "i1", "name": "image1", "is_public": true,  "size": "1024", "min_ram": "1", "min_disk": "10" },
+                  { "id": "i2", "name": "image2", "is_public": false, "size": "2048", "min_ram": "2", "min_disk": "20" }
+                ]
+              }')
 
           images = @glance_client.get_all_images(env)
 
@@ -109,32 +108,32 @@ describe VagrantPlugins::Openstack::GlanceClient do
   describe 'get_api_version_list' do
     it 'returns version list' do
       stub_request(:get, 'http://glance/')
-      .with(header: { 'Accept' => 'application/json' })
-      .to_return(
-        status: 200,
-        body: '{
-          "versions": [
-            {
-              "status": "...",
-              "id": "v1.0",
-              "links": [
-                {
-                  "href": "http://glance/v1.0",
-                  "rel": "self"
-                }
-              ]
-            },
-            {
-              "status": "CURRENT",
-              "id": "v2.0",
-              "links": [
-                {
-                  "href": "http://glance/v2.0",
-                  "rel": "self"
-                }
-              ]
-            }
-          ]}')
+        .with(header: { 'Accept' => 'application/json' })
+        .to_return(
+          status: 200,
+          body: '{
+            "versions": [
+              {
+                "status": "...",
+                "id": "v1.0",
+                "links": [
+                  {
+                    "href": "http://glance/v1.0",
+                    "rel": "self"
+                  }
+                ]
+              },
+              {
+                "status": "CURRENT",
+                "id": "v2.0",
+                "links": [
+                  {
+                    "href": "http://glance/v2.0",
+                    "rel": "self"
+                  }
+                ]
+              }
+            ]}')
 
       versions = @glance_client.get_api_version_list(env)
 

--- a/source/spec/vagrant-openstack-provider/client/heat_spec.rb
+++ b/source/spec/vagrant-openstack-provider/client/heat_spec.rb
@@ -22,7 +22,7 @@ describe VagrantPlugins::Openstack::NovaClient do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:ui] = double('ui')
       env[:ui].stub(:info).with(anything)
       env[:machine] = double('machine')
@@ -45,19 +45,18 @@ describe VagrantPlugins::Openstack::NovaClient do
     context 'stack not found' do
       it 'raise an StackNotFound error' do
         stub_request(:get, 'http://heat/a1b2c3/stacks/stack_name/stack_id')
-            .with(
-              headers:
-              {
-                'Accept' => 'application/json',
-                'Accept-Encoding' => 'gzip, deflate',
-                'X-Auth-Token' => '123456'
-              })
-            .to_return(
-              status: 404,
-              body: '{"itemNotFound": {"message": "Stack could not be found", "code": 404}}')
+          .with(
+            headers:
+            {
+              'Accept' => 'application/json',
+              'Accept-Encoding' => 'gzip, deflate',
+              'X-Auth-Token' => '123456'
+            })
+          .to_return(
+            status: 404,
+            body: '{"itemNotFound": {"message": "Stack could not be found", "code": 404}}')
 
         expect { @heat_client.get_stack_details(env, 'stack_name', 'stack_id') }.to raise_error(VagrantPlugins::Openstack::Errors::StackNotFound)
-
       end
     end
   end
@@ -65,17 +64,16 @@ describe VagrantPlugins::Openstack::NovaClient do
   describe 'create_stack' do
     context 'with token and project_id acquainted' do
       it 'returns new stack id' do
-
         stub_request(:post, 'http://heat/a1b2c3/stacks')
-            .with(
-              body: '{"stack_name":"stck","template":"toto"}',
-              headers:
-              {
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/json',
-                'X-Auth-Token' => '123456'
-              })
-            .to_return(status: 202, body: '{ "stack": { "id": "o1o2o3" } }')
+          .with(
+            body: '{"stack_name":"stck","template":"toto"}',
+            headers:
+            {
+              'Accept' => 'application/json',
+              'Content-Type' => 'application/json',
+              'X-Auth-Token' => '123456'
+            })
+          .to_return(status: 202, body: '{ "stack": { "id": "o1o2o3" } }')
 
         stack_id = @heat_client.create_stack(env, name: 'stck', template: 'toto')
 
@@ -87,14 +85,13 @@ describe VagrantPlugins::Openstack::NovaClient do
   describe 'get_stack_details' do
     context 'with token and project_id acquainted' do
       it 'returns stack details' do
-
         stub_request(:get, 'http://heat/a1b2c3/stacks/stack_id/stack_name')
-            .with(headers:
+          .with(headers:
               {
                 'Accept' => 'application/json',
                 'X-Auth-Token' => '123456'
               })
-            .to_return(status: 200, body: '
+          .to_return(status: 200, body: '
             {
                 "stack": {
                     "description": "sample stack",
@@ -116,14 +113,13 @@ describe VagrantPlugins::Openstack::NovaClient do
   describe 'delete_stack' do
     context 'with token and project_id acquainted' do
       it 'deletes the stack' do
-
         stub_request(:delete, 'http://heat/a1b2c3/stacks/stack_id/stack_name')
-            .with(headers:
+          .with(headers:
               {
                 'Accept' => 'application/json',
                 'X-Auth-Token' => '123456'
               })
-            .to_return(status: 204)
+          .to_return(status: 204)
 
         @heat_client.delete_stack(env, 'stack_id', 'stack_name')
       end

--- a/source/spec/vagrant-openstack-provider/client/keystone_spec.rb
+++ b/source/spec/vagrant-openstack-provider/client/keystone_spec.rb
@@ -1,7 +1,6 @@
 require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::KeystoneClient do
-
   let(:http) do
     double('http').tap do |http|
       http.stub(:read_timeout) { 42 }
@@ -22,7 +21,7 @@ describe VagrantPlugins::Openstack::KeystoneClient do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:ui] = double('ui')
       env[:ui].stub(:info).with(anything)
       env[:machine] = double('machine')
@@ -35,7 +34,6 @@ describe VagrantPlugins::Openstack::KeystoneClient do
   end
 
   describe 'authenticate' do
-
     let(:keystone_request_headers) do
       {
         'Accept' => 'application/json',
@@ -61,10 +59,10 @@ describe VagrantPlugins::Openstack::KeystoneClient do
     context 'with good credentials' do
       it 'store token and tenant id' do
         stub_request(:post, 'http://keystoneAuthV2/tokens')
-        .with(
+          .with(
             body: keystone_request_body,
             headers: keystone_request_headers)
-        .to_return(
+          .to_return(
             status: 200,
             body: keystone_response_body,
             headers: keystone_request_headers)
@@ -79,10 +77,10 @@ describe VagrantPlugins::Openstack::KeystoneClient do
     context 'with wrong credentials' do
       it 'raise an unauthorized error' do
         stub_request(:post, 'http://keystoneAuthV2/tokens')
-        .with(
+          .with(
             body: keystone_request_body,
             headers: keystone_request_headers)
-        .to_return(
+          .to_return(
             status: 401,
             body: '{
                 "error": {
@@ -100,10 +98,10 @@ describe VagrantPlugins::Openstack::KeystoneClient do
     context 'with bad endpoint' do
       it 'raise a BadAuthenticationEndpoint error' do
         stub_request(:post, 'http://keystoneAuthV2/tokens')
-        .with(
+          .with(
             body: keystone_request_body,
             headers: keystone_request_headers)
-        .to_return(
+          .to_return(
             status: 404)
 
         expect { @keystone_client.authenticate(env) }.to raise_error(Errors::BadAuthenticationEndpoint)
@@ -115,10 +113,10 @@ describe VagrantPlugins::Openstack::KeystoneClient do
         config.stub(:openstack_auth_url) { 'http://keystoneAuthV2' }
 
         stub_request(:post, 'http://keystoneAuthV2/tokens')
-        .with(
+          .with(
             body: keystone_request_body,
             headers: keystone_request_headers)
-        .to_return(
+          .to_return(
             status: 200,
             body: keystone_response_body,
             headers: keystone_request_headers)
@@ -133,10 +131,10 @@ describe VagrantPlugins::Openstack::KeystoneClient do
     context 'with internal server error' do
       it 'raise a VagrantOpenstackError error with response body as message' do
         stub_request(:post, 'http://keystoneAuthV2/tokens')
-        .with(
+          .with(
             body: keystone_request_body,
             headers: keystone_request_headers)
-        .to_return(
+          .to_return(
             status: 500,
             body: 'Internal server error')
 

--- a/source/spec/vagrant-openstack-provider/client/neutron_spec.rb
+++ b/source/spec/vagrant-openstack-provider/client/neutron_spec.rb
@@ -1,7 +1,6 @@
 require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::NeutronClient do
-
   let(:http) do
     double('http').tap do |http|
       http.stub(:read_timeout) { 42 }
@@ -16,7 +15,7 @@ describe VagrantPlugins::Openstack::NeutronClient do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:machine] = double('machine')
       env[:machine].stub(:provider_config) { config }
     end
@@ -36,25 +35,24 @@ describe VagrantPlugins::Openstack::NeutronClient do
   describe 'get_private_networks' do
     context 'with token' do
       it 'returns only private networks for project in session' do
-
         stub_request(:get, 'http://neutron/networks')
-            .with(
-              headers:
+          .with(
+            headers:
+            {
+              'Accept' => 'application/json',
+              'X-Auth-Token' => '123456'
+            })
+          .to_return(
+            status: 200,
+            body: '
               {
-                'Accept' => 'application/json',
-                'X-Auth-Token' => '123456'
-              })
-            .to_return(
-              status: 200,
-              body: '
-                {
-                  "networks": [
-                    { "name": "PublicNetwork", "tenant_id": "admin-tenant-id", "id": "net-pub" },
-                    { "name": "net1", "tenant_id": "a1b2c3", "id": "net-1" },
-                    { "name": "net2", "tenant_id": "a1b2c3", "id": "net-2" }
-                  ]
-                }
-              ')
+                "networks": [
+                  { "name": "PublicNetwork", "tenant_id": "admin-tenant-id", "id": "net-pub" },
+                  { "name": "net1", "tenant_id": "a1b2c3", "id": "net-1" },
+                  { "name": "net2", "tenant_id": "a1b2c3", "id": "net-2" }
+                ]
+              }
+            ')
 
         networks = @neutron_client.get_private_networks(env)
 
@@ -70,25 +68,24 @@ describe VagrantPlugins::Openstack::NeutronClient do
   describe 'get_all_networks' do
     context 'with token' do
       it 'returns all networks for project in session' do
-
         stub_request(:get, 'http://neutron/networks')
-            .with(
-              headers:
+          .with(
+            headers:
+            {
+              'Accept' => 'application/json',
+              'X-Auth-Token' => '123456'
+            })
+          .to_return(
+            status: 200,
+            body: '
               {
-                'Accept' => 'application/json',
-                'X-Auth-Token' => '123456'
-              })
-            .to_return(
-              status: 200,
-              body: '
-                {
-                  "networks": [
-                    { "name": "PublicNetwork", "tenant_id": "admin-tenant-id", "id": "net-pub" },
-                    { "name": "net1", "tenant_id": "a1b2c3", "id": "net-1" },
-                    { "name": "net2", "tenant_id": "a1b2c3", "id": "net-2" }
-                  ]
-                }
-              ')
+                "networks": [
+                  { "name": "PublicNetwork", "tenant_id": "admin-tenant-id", "id": "net-pub" },
+                  { "name": "net1", "tenant_id": "a1b2c3", "id": "net-1" },
+                  { "name": "net2", "tenant_id": "a1b2c3", "id": "net-2" }
+                ]
+              }
+            ')
 
         networks = @neutron_client.get_all_networks(env)
 
@@ -106,25 +103,24 @@ describe VagrantPlugins::Openstack::NeutronClient do
   describe 'get_subnets' do
     context 'with token' do
       it 'returns all available subnets' do
-
         stub_request(:get, 'http://neutron/subnets')
-        .with(
-          headers:
-            {
-              'Accept' => 'application/json',
-              'X-Auth-Token' => '123456'
-            })
-        .to_return(
-          status: 200,
-          body: '
-                {
-                  "subnets": [
-                    { "id": "subnet-01", "name": "Subnet 1", "cidr": "192.168.1.0/24", "enable_dhcp": true, "network_id": "net-01" },
-                    { "id": "subnet-02", "name": "Subnet 2", "cidr": "192.168.2.0/24", "enable_dhcp": false, "network_id": "net-01" },
-                    { "id": "subnet-03", "name": "Subnet 3", "cidr": "192.168.100.0/24", "enable_dhcp": true, "network_id": "net-02" }
-                  ]
-                }
-                ')
+          .with(
+            headers:
+              {
+                'Accept' => 'application/json',
+                'X-Auth-Token' => '123456'
+              })
+          .to_return(
+            status: 200,
+            body: '
+                  {
+                    "subnets": [
+                      { "id": "subnet-01", "name": "Subnet 1", "cidr": "192.168.1.0/24", "enable_dhcp": true, "network_id": "net-01" },
+                      { "id": "subnet-02", "name": "Subnet 2", "cidr": "192.168.2.0/24", "enable_dhcp": false, "network_id": "net-01" },
+                      { "id": "subnet-03", "name": "Subnet 3", "cidr": "192.168.100.0/24", "enable_dhcp": true, "network_id": "net-02" }
+                    ]
+                  }
+                  ')
 
         networks = @neutron_client.get_subnets(env)
 
@@ -139,32 +135,32 @@ describe VagrantPlugins::Openstack::NeutronClient do
     context 'basic' do
       it 'returns version list' do
         stub_request(:get, 'http://neutron/')
-        .with(header: { 'Accept' => 'application/json' })
-        .to_return(
-          status: 200,
-          body: '{
-            "versions": [
-              {
-                "status": "...",
-                "id": "v1.0",
-                "links": [
-                  {
-                    "href": "http://neutron/v1.0",
-                    "rel": "self"
-                  }
-                ]
-              },
-              {
-                "status": "CURRENT",
-                "id": "v2.0",
-                "links": [
-                  {
-                    "href": "http://neutron/v2.0",
-                    "rel": "self"
-                  }
-                ]
-              }
-            ]}')
+          .with(header: { 'Accept' => 'application/json' })
+          .to_return(
+            status: 200,
+            body: '{
+              "versions": [
+                {
+                  "status": "...",
+                  "id": "v1.0",
+                  "links": [
+                    {
+                      "href": "http://neutron/v1.0",
+                      "rel": "self"
+                    }
+                  ]
+                },
+                {
+                  "status": "CURRENT",
+                  "id": "v2.0",
+                  "links": [
+                    {
+                      "href": "http://neutron/v2.0",
+                      "rel": "self"
+                    }
+                  ]
+                }
+              ]}')
 
         versions = @neutron_client.get_api_version_list(env, :network)
 

--- a/source/spec/vagrant-openstack-provider/client/nova_spec.rb
+++ b/source/spec/vagrant-openstack-provider/client/nova_spec.rb
@@ -31,7 +31,7 @@ describe VagrantPlugins::Openstack::NovaClient do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:ui] = double('ui')
       env[:ui].stub(:info).with(anything)
       env[:machine] = double('machine')
@@ -54,20 +54,19 @@ describe VagrantPlugins::Openstack::NovaClient do
     context 'instance not found' do
       it 'raise an InstanceNotFound error' do
         stub_request(:post, 'http://nova/a1b2c3/servers/o1o2o3/action')
-            .with(
-              body: '{"os-start":null}',
-              headers:
-              {
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/json',
-                'X-Auth-Token' => '123456'
-              })
-            .to_return(
-              status: 404,
-              body: '{"itemNotFound": {"message": "Instance could not be found", "code": 404}}')
+          .with(
+            body: '{"os-start":null}',
+            headers:
+            {
+              'Accept' => 'application/json',
+              'Content-Type' => 'application/json',
+              'X-Auth-Token' => '123456'
+            })
+          .to_return(
+            status: 404,
+            body: '{"itemNotFound": {"message": "Instance could not be found", "code": 404}}')
 
         expect { @nova_client.start_server(env, 'o1o2o3') }.to raise_error(VagrantPlugins::Openstack::Errors::InstanceNotFound)
-
       end
     end
   end
@@ -76,19 +75,19 @@ describe VagrantPlugins::Openstack::NovaClient do
     context 'with token and project_id acquainted' do
       it 'returns all flavors' do
         stub_request(:get, 'http://nova/a1b2c3/flavors/detail')
-            .with(
-              headers:
-              {
-                'Accept' => 'application/json',
-                'X-Auth-Token' => '123456'
-              })
-            .to_return(
-              status: 200,
-              body: '{
-                "flavors": [
-                  { "id": "f1", "name": "flavor1", "vcpus":"1", "ram": "1024", "disk": "10"},
-                  { "id": "f2", "name": "flavor2", "vcpus":"2", "ram": "2048", "disk": "20"}
-                ]}')
+          .with(
+            headers:
+            {
+              'Accept' => 'application/json',
+              'X-Auth-Token' => '123456'
+            })
+          .to_return(
+            status: 200,
+            body: '{
+              "flavors": [
+                { "id": "f1", "name": "flavor1", "vcpus":"1", "ram": "1024", "disk": "10"},
+                { "id": "f2", "name": "flavor2", "vcpus":"2", "ram": "2048", "disk": "20"}
+              ]}')
 
         flavors = @nova_client.get_all_flavors(env)
 
@@ -103,15 +102,15 @@ describe VagrantPlugins::Openstack::NovaClient do
     context 'with token and project_id acquainted' do
       it 'returns all images' do
         stub_request(:get, 'http://nova/a1b2c3/images')
-            .with(
-              headers:
-              {
-                'Accept' => 'application/json',
-                'X-Auth-Token' => '123456'
-              })
-            .to_return(
-              status: 200,
-              body: '{ "images": [ { "id": "i1", "name": "image1"}, { "id": "i2", "name": "image2"} ] }')
+          .with(
+            headers:
+            {
+              'Accept' => 'application/json',
+              'X-Auth-Token' => '123456'
+            })
+          .to_return(
+            status: 200,
+            body: '{ "images": [ { "id": "i1", "name": "image1"}, { "id": "i2", "name": "image2"} ] }')
 
         images = @nova_client.get_all_images(env)
 
@@ -127,17 +126,16 @@ describe VagrantPlugins::Openstack::NovaClient do
   describe 'create_server' do
     context 'with token and project_id acquainted' do
       it 'returns new instance id' do
-
         stub_request(:post, 'http://nova/a1b2c3/servers')
-            .with(
-              body: '{"server":{"name":"inst","imageRef":"img","flavorRef":"flav","key_name":"key"}}',
-              headers:
-              {
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/json',
-                'X-Auth-Token' => '123456'
-              })
-            .to_return(status: 202, body: '{ "server": { "id": "o1o2o3" } }')
+          .with(
+            body: '{"server":{"name":"inst","imageRef":"img","flavorRef":"flav","key_name":"key"}}',
+            headers:
+            {
+              'Accept' => 'application/json',
+              'Content-Type' => 'application/json',
+              'X-Auth-Token' => '123456'
+            })
+          .to_return(status: 202, body: '{ "server": { "id": "o1o2o3" } }')
 
         instance_id = @nova_client.create_server(env, name: 'inst', image_ref: 'img', flavor_ref: 'flav', networks: nil, keypair: 'key')
 
@@ -147,17 +145,17 @@ describe VagrantPlugins::Openstack::NovaClient do
       context 'with all options specified' do
         it 'returns new instance id' do
           stub_request(:post, 'http://nova/a1b2c3/servers')
-              .with(
-                body: '{"server":{"name":"inst","imageRef":"img","flavorRef":"flav","key_name":"key",'\
-                '"security_groups":[{"name":"default"}],"user_data":"dXNlcl9kYXRhX3Rlc3Q=\n","metadata":"metadata_test"},'\
-                '"scheduler_hints":"sched_hints_test"}',
-                headers:
-                {
-                  'Accept' => 'application/json',
-                  'Content-Type' => 'application/json',
-                  'X-Auth-Token' => '123456'
-                })
-              .to_return(status: 202, body: '{ "server": { "id": "o1o2o3" } }')
+            .with(
+              body: '{"server":{"name":"inst","imageRef":"img","flavorRef":"flav","key_name":"key",'\
+              '"security_groups":[{"name":"default"}],"user_data":"dXNlcl9kYXRhX3Rlc3Q=\n","metadata":"metadata_test"},'\
+              '"scheduler_hints":"sched_hints_test"}',
+              headers:
+              {
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+                'X-Auth-Token' => '123456'
+              })
+            .to_return(status: 202, body: '{ "server": { "id": "o1o2o3" } }')
 
           instance_id = @nova_client.create_server(
             env,
@@ -177,9 +175,8 @@ describe VagrantPlugins::Openstack::NovaClient do
 
       context 'with two networks' do
         it 'returns new instance id' do
-
           stub_request(:post, 'http://nova/a1b2c3/servers')
-          .with(
+            .with(
               body: '{"server":{"name":"inst","imageRef":"img","flavorRef":"flav","key_name":"key","networks":[{"uuid":"net1"},{"uuid":"net2"}]}}',
               headers:
                   {
@@ -187,7 +184,7 @@ describe VagrantPlugins::Openstack::NovaClient do
                     'Content-Type' => 'application/json',
                     'X-Auth-Token' => '123456'
                   })
-          .to_return(status: 202, body: '{ "server": { "id": "o1o2o3" } }')
+            .to_return(status: 202, body: '{ "server": { "id": "o1o2o3" } }')
 
           instance_id = @nova_client.create_server(env, name: 'inst', image_ref: 'img', flavor_ref: 'flav',
                                                         networks: [{ uuid: 'net1' }, { uuid: 'net2' }], keypair: 'key')
@@ -198,9 +195,8 @@ describe VagrantPlugins::Openstack::NovaClient do
 
       context 'with availability_zone' do
         it 'returns new instance id' do
-
           stub_request(:post, 'http://nova/a1b2c3/servers')
-          .with(
+            .with(
               body: '{"server":{"name":"inst","imageRef":"img","flavorRef":"flav","key_name":"key","availability_zone":"avz"}}',
               headers:
                   {
@@ -208,7 +204,7 @@ describe VagrantPlugins::Openstack::NovaClient do
                     'Content-Type' => 'application/json',
                     'X-Auth-Token' => '123456'
                   })
-          .to_return(status: 202, body: '{ "server": { "id": "o1o2o3" } }')
+            .to_return(status: 202, body: '{ "server": { "id": "o1o2o3" } }')
 
           instance_id = @nova_client.create_server(env, name: 'inst', image_ref: 'img', flavor_ref: 'flav', keypair: 'key', availability_zone: 'avz')
 
@@ -218,9 +214,8 @@ describe VagrantPlugins::Openstack::NovaClient do
 
       context 'with volume_boot' do
         it 'returns new instance id' do
-
           stub_request(:post, 'http://nova/a1b2c3/servers')
-          .with(
+            .with(
               body: '{"server":{"name":"inst","block_device_mapping":[{"volume_id":"vol","device_name":"vda"}],"flavorRef":"flav","key_name":"key"}}',
               headers:
                   {
@@ -228,7 +223,7 @@ describe VagrantPlugins::Openstack::NovaClient do
                     'Content-Type' => 'application/json',
                     'X-Auth-Token' => '123456'
                   })
-          .to_return(status: 202, body: '{ "server": { "id": "o1o2o3" } }')
+            .to_return(status: 202, body: '{ "server": { "id": "o1o2o3" } }')
 
           instance_id = @nova_client.create_server(env, name: 'inst', volume_boot: { id: 'vol', device: 'vda' }, flavor_ref: 'flav', keypair: 'key')
 
@@ -241,17 +236,15 @@ describe VagrantPlugins::Openstack::NovaClient do
   describe 'delete_server' do
     context 'with token and project_id acquainted' do
       it 'returns new instance id' do
-
         stub_request(:delete, 'http://nova/a1b2c3/servers/o1o2o3')
-            .with(
-              headers: {
-                'Accept' => 'application/json',
-                'X-Auth-Token' => '123456'
-              })
-            .to_return(status: 204)
+          .with(
+            headers: {
+              'Accept' => 'application/json',
+              'X-Auth-Token' => '123456'
+            })
+          .to_return(status: 204)
 
         @nova_client.delete_server(env, 'o1o2o3')
-
       end
     end
   end
@@ -264,13 +257,13 @@ describe VagrantPlugins::Openstack::NovaClient do
         Kernel.stub(:rand).and_return(2_036_069_739_008)
 
         stub_request(:post, 'http://nova/a1b2c3/os-keypairs')
-            .with(
-              body: "{\"keypair\":{\"name\":\"vagrant-generated-pzcvcpa8\",\"public_key\":\"#{ssh_key_content}\"}}",
-              headers: {
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/json',
-                'X-Auth-Token' => '123456' })
-              .to_return(status: 200, body: '
+          .with(
+            body: "{\"keypair\":{\"name\":\"vagrant-generated-pzcvcpa8\",\"public_key\":\"#{ssh_key_content}\"}}",
+            headers: {
+              'Accept' => 'application/json',
+              'Content-Type' => 'application/json',
+              'X-Auth-Token' => '123456' })
+          .to_return(status: 200, body: '
               {
                 "keypair": {
                   "name": "created_key_name"
@@ -278,7 +271,6 @@ describe VagrantPlugins::Openstack::NovaClient do
               }')
 
         @nova_client.import_keypair_from_file(env, filename)
-
       end
     end
   end
@@ -288,12 +280,12 @@ describe VagrantPlugins::Openstack::NovaClient do
       context 'with keypair not generated by vagrant' do
         it 'do nothing' do
           stub_request(:get, 'http://nova/a1b2c3/servers/o1o2o3')
-              .with(headers:
+            .with(headers:
                 {
                   'Accept' => 'application/json',
                   'X-Auth-Token' => '123456'
                 })
-              .to_return(status: 200, body: '
+            .to_return(status: 200, body: '
                 {
                   "server": {
                      "id": "o1o2o3",
@@ -308,15 +300,15 @@ describe VagrantPlugins::Openstack::NovaClient do
       context 'with keypair generated by vagrant' do
         it 'deletes the key on nova' do
           stub_request(:delete, 'http://nova/a1b2c3/os-keypairs/vagrant-generated-1234')
-                .with(headers: { 'X-Auth-Token' => '123456' })
-                .to_return(status: 202)
+            .with(headers: { 'X-Auth-Token' => '123456' })
+            .to_return(status: 202)
           stub_request(:get, 'http://nova/a1b2c3/servers/o1o2o3')
-              .with(headers:
+            .with(headers:
                 {
                   'Accept' => 'application/json',
                   'X-Auth-Token' => '123456'
                 })
-              .to_return(status: 200, body: '
+            .to_return(status: 200, body: '
                 {
                   "server": {
                      "id": "o1o2o3",
@@ -334,17 +326,16 @@ describe VagrantPlugins::Openstack::NovaClient do
   describe 'suspend_server' do
     context 'with token and project_id acquainted' do
       it 'returns new instance id' do
-
         stub_request(:post, 'http://nova/a1b2c3/servers/o1o2o3/action')
-            .with(
-              body: '{"suspend":null}',
-              headers:
-              {
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/json',
-                'X-Auth-Token' => '123456'
-              })
-            .to_return(status: 202)
+          .with(
+            body: '{"suspend":null}',
+            headers:
+            {
+              'Accept' => 'application/json',
+              'Content-Type' => 'application/json',
+              'X-Auth-Token' => '123456'
+            })
+          .to_return(status: 202)
 
         @nova_client.suspend_server(env, 'o1o2o3')
       end
@@ -354,17 +345,16 @@ describe VagrantPlugins::Openstack::NovaClient do
   describe 'resume_server' do
     context 'with token and project_id acquainted' do
       it 'returns new instance id' do
-
         stub_request(:post, 'http://nova/a1b2c3/servers/o1o2o3/action')
-            .with(
-              body: '{"resume":null}',
-              headers:
-              {
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/json',
-                'X-Auth-Token' => '123456'
-              })
-            .to_return(status: 202)
+          .with(
+            body: '{"resume":null}',
+            headers:
+            {
+              'Accept' => 'application/json',
+              'Content-Type' => 'application/json',
+              'X-Auth-Token' => '123456'
+            })
+          .to_return(status: 202)
 
         @nova_client.resume_server(env, 'o1o2o3')
       end
@@ -374,20 +364,18 @@ describe VagrantPlugins::Openstack::NovaClient do
   describe 'stop_server' do
     context 'with token and project_id acquainted' do
       it 'returns new instance id' do
-
         stub_request(:post, 'http://nova/a1b2c3/servers/o1o2o3/action')
-            .with(
-              body: '{"os-stop":null}',
-              headers:
-              {
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/json',
-                'X-Auth-Token' => '123456'
-              })
-            .to_return(status: 202)
+          .with(
+            body: '{"os-stop":null}',
+            headers:
+            {
+              'Accept' => 'application/json',
+              'Content-Type' => 'application/json',
+              'X-Auth-Token' => '123456'
+            })
+          .to_return(status: 202)
 
         @nova_client.stop_server(env, 'o1o2o3')
-
       end
     end
   end
@@ -395,20 +383,18 @@ describe VagrantPlugins::Openstack::NovaClient do
   describe 'start_server' do
     context 'with token and project_id acquainted' do
       it 'returns new instance id' do
-
         stub_request(:post, 'http://nova/a1b2c3/servers/o1o2o3/action')
-            .with(
-              body: '{"os-start":null}',
-              headers:
-              {
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/json',
-                'X-Auth-Token' => '123456'
-              })
-            .to_return(status: 202)
+          .with(
+            body: '{"os-start":null}',
+            headers:
+            {
+              'Accept' => 'application/json',
+              'Content-Type' => 'application/json',
+              'X-Auth-Token' => '123456'
+            })
+          .to_return(status: 202)
 
         @nova_client.start_server(env, 'o1o2o3')
-
       end
     end
   end
@@ -417,14 +403,14 @@ describe VagrantPlugins::Openstack::NovaClient do
     context 'with token and project_id acquainted' do
       it 'returns all floating ips' do
         stub_request(:get, 'http://nova/a1b2c3/os-floating-ips')
-         .with(headers:
+          .with(headers:
           {
             'Accept' => 'application/json',
             'Accept-Encoding' => 'gzip, deflate',
             'User-Agent' => 'Ruby',
             'X-Auth-Token' => '123456'
           })
-         .to_return(status: 200, body: '
+          .to_return(status: 200, body: '
          {
            "floating_ips": [
              {"instance_id": "1234",
@@ -460,12 +446,12 @@ describe VagrantPlugins::Openstack::NovaClient do
     context 'with token and project_id acquainted' do
       it 'return newly allocated floating_ip' do
         stub_request(:post, 'http://nova/a1b2c3/os-floating-ips')
-         .with(body: '{"pool":"pool-1"}',
-               headers: {
-                 'Accept' => 'application/json',
-                 'Content-Type' => 'application/json',
-                 'X-Auth-Token' => '123456' })
-         .to_return(status: 200, body: '
+          .with(body: '{"pool":"pool-1"}',
+                headers: {
+                  'Accept' => 'application/json',
+                  'Content-Type' => 'application/json',
+                  'X-Auth-Token' => '123456' })
+          .to_return(status: 200, body: '
          {
            "floating_ip": {
               "instance_id": null,
@@ -487,14 +473,13 @@ describe VagrantPlugins::Openstack::NovaClient do
   describe 'get_server_details' do
     context 'with token and project_id acquainted' do
       it 'returns server details' do
-
         stub_request(:get, 'http://nova/a1b2c3/servers/o1o2o3')
-            .with(headers:
+          .with(headers:
               {
                 'Accept' => 'application/json',
                 'X-Auth-Token' => '123456'
               })
-            .to_return(status: 200, body: '
+          .to_return(status: 200, body: '
               {
                 "server": {
                    "addresses": { "private": [ { "addr": "192.168.0.3", "version": 4 } ] },
@@ -519,23 +504,20 @@ describe VagrantPlugins::Openstack::NovaClient do
         expect(server['tenant_id']).to eq('openstack')
         expect(server['image']['id']).to eq('i1')
         expect(server['flavor']['id']).to eq('1')
-
       end
     end
   end
 
   describe 'add_floating_ip' do
-
     context 'with token and project_id acquainted and IP available' do
       it 'returns server details' do
-
         stub_request(:get, 'http://nova/a1b2c3/os-floating-ips')
-            .with(headers:
+          .with(headers:
               {
                 'Accept' => 'application/json',
                 'X-Auth-Token' => '123456'
               })
-            .to_return(status: 200, body: '
+          .to_return(status: 200, body: '
               {
                   "floating_ips": [
                       {
@@ -556,14 +538,14 @@ describe VagrantPlugins::Openstack::NovaClient do
               }')
 
         stub_request(:post, 'http://nova/a1b2c3/servers/o1o2o3/action')
-            .with(body: '{"addFloatingIp":{"address":"1.2.3.4"}}',
-                  headers:
+          .with(body: '{"addFloatingIp":{"address":"1.2.3.4"}}',
+                headers:
                   {
                     'Accept' => 'application/json',
                     'Content-Type' => 'application/json',
                     'X-Auth-Token' => '123456'
                   })
-            .to_return(status: 202)
+          .to_return(status: 202)
 
         @nova_client.add_floating_ip(env, 'o1o2o3', '1.2.3.4')
       end
@@ -571,14 +553,13 @@ describe VagrantPlugins::Openstack::NovaClient do
 
     context 'with token and project_id acquainted and IP already in use' do
       it 'raise an error' do
-
         stub_request(:get, 'http://nova/a1b2c3/os-floating-ips')
-            .with(headers:
+          .with(headers:
               {
                 'Accept' => 'application/json',
                 'X-Auth-Token' => '123456'
               })
-            .to_return(status: 200, body: '
+          .to_return(status: 200, body: '
               {
                   "floating_ips": [
                       {
@@ -604,14 +585,13 @@ describe VagrantPlugins::Openstack::NovaClient do
 
     context 'with token and project_id acquainted and IP not allocated' do
       it 'raise an error' do
-
         stub_request(:get, 'http://nova/a1b2c3/os-floating-ips')
-            .with(headers:
+          .with(headers:
               {
                 'Accept' => 'application/json',
                 'X-Auth-Token' => '123456'
               })
-            .to_return(status: 200, body: '
+          .to_return(status: 200, body: '
               {
                   "floating_ips": [
                       {
@@ -632,7 +612,6 @@ describe VagrantPlugins::Openstack::NovaClient do
   describe 'get_floating_ip_pools' do
     context 'with token and project_id acquainted' do
       it 'should return floating ip pool' do
-
         stub_request(:get, 'http://nova/a1b2c3/os-floating-ip-pools')
           .with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => '123456' })
           .to_return(status: 200, body: '
@@ -659,7 +638,6 @@ describe VagrantPlugins::Openstack::NovaClient do
   describe 'get_floating_ips' do
     context 'with token and project_id acquainted' do
       it 'should return floating ip list' do
-
         stub_request(:get, 'http://nova/a1b2c3/os-floating-ips')
           .with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => '123456' })
           .to_return(status: 200, body: '
@@ -701,13 +679,13 @@ describe VagrantPlugins::Openstack::NovaClient do
       context 'with volume id and device' do
         it 'call the nova api' do
           stub_request(:post, 'http://nova/a1b2c3/servers/9876/os-volume_attachments')
-          .with(headers:
+            .with(headers:
                   {
                     'Accept' => 'application/json',
                     'X-Auth-Token' => '123456'
                   },
-                body: '{"volumeAttachment":{"volumeId":"n1n2","device":"/dev/vdg"}}')
-          .to_return(status: 200, body: '
+                  body: '{"volumeAttachment":{"volumeId":"n1n2","device":"/dev/vdg"}}')
+            .to_return(status: 200, body: '
                   {
                     "volumeAttachment": {
                       "device": "/dev/vdg",

--- a/source/spec/vagrant-openstack-provider/client/nova_spec.rb
+++ b/source/spec/vagrant-openstack-provider/client/nova_spec.rb
@@ -212,21 +212,57 @@ describe VagrantPlugins::Openstack::NovaClient do
         end
       end
 
-      context 'with volume_boot' do
+      context 'with volume_boot creating volume' do
+        it 'create bootable volume and returns new instance id' do
+          stub_request(:post, 'http://nova/a1b2c3/servers')
+            .with(
+              body: '{"server":{"name":"inst","block_device_mapping_v2":[{"boot_index":"0","volume_size":"10","uuid":"image_id",'\
+              '"device_name":"vda","source_type":"image","destination_type":"volume","delete_on_termination":"false"}],'\
+              '"flavorRef":"flav","key_name":"key"}}',
+              headers:
+              {
+                'Accept' => 'application/json',
+                'Accept-Encoding' => 'gzip, deflate',
+                'Content-Length' => '248',
+                'Content-Type' => 'application/json',
+                'User-Agent' => 'Ruby',
+                'X-Auth-Token' => '123456'
+              })
+            .to_return(status: 202, body: '{ "server": { "id": "o1o2o3" } }')
+
+          instance_id = @nova_client.create_server(env,
+                                                   name: 'inst',
+                                                   image_ref: nil,
+                                                   volume_boot: { image: 'image_id', device: 'vda', size: '10',
+                                                                  delete_on_destroy: 'false' },
+                                                   flavor_ref: 'flav',
+                                                   keypair: 'key')
+          expect(instance_id).to eq('o1o2o3')
+        end
+      end
+
+      context 'with volume_boot id' do
         it 'returns new instance id' do
           stub_request(:post, 'http://nova/a1b2c3/servers')
             .with(
-              body: '{"server":{"name":"inst","block_device_mapping":[{"volume_id":"vol","device_name":"vda"}],"flavorRef":"flav","key_name":"key"}}',
+              body: '{"server":{"name":"inst","block_device_mapping":[{"volume_id":"vol","device_name":"vda"}],'\
+              '"flavorRef":"flav","key_name":"key"}}',
               headers:
-                  {
-                    'Accept' => 'application/json',
-                    'Content-Type' => 'application/json',
-                    'X-Auth-Token' => '123456'
-                  })
+              {
+                'Accept' => 'application/json',
+                'Accept-Encoding' => 'gzip, deflate',
+                'Content-Length' => '127',
+                'Content-Type' => 'application/json',
+                'User-Agent' => 'Ruby',
+                'X-Auth-Token' => '123456'
+              })
             .to_return(status: 202, body: '{ "server": { "id": "o1o2o3" } }')
 
-          instance_id = @nova_client.create_server(env, name: 'inst', volume_boot: { id: 'vol', device: 'vda' }, flavor_ref: 'flav', keypair: 'key')
-
+          instance_id = @nova_client.create_server(env,
+                                                   name: 'inst',
+                                                   volume_boot: { id: 'vol', device: 'vda' },
+                                                   flavor_ref: 'flav',
+                                                   keypair: 'key')
           expect(instance_id).to eq('o1o2o3')
         end
       end

--- a/source/spec/vagrant-openstack-provider/client/utils_spec.rb
+++ b/source/spec/vagrant-openstack-provider/client/utils_spec.rb
@@ -3,7 +3,6 @@ require 'vagrant-openstack-provider/spec_helper'
 include VagrantPlugins::Openstack
 
 describe VagrantPlugins::Openstack::HttpUtils do
-
   let(:keystone) do
     double('keystone').tap do |keystone|
       keystone.stub(:authenticate).with(anything)
@@ -11,7 +10,7 @@ describe VagrantPlugins::Openstack::HttpUtils do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:ui] = double('ui')
       env[:ui].stub(:warn).with(anything)
       env[:openstack_client] = double('openstack_client')
@@ -37,7 +36,6 @@ describe VagrantPlugins::Openstack::HttpUtils do
   end
 
   describe 'authenticated' do
-
     before :each do
       TestUtils.send(:public, *TestUtils.private_instance_methods)
       @utils = TestUtils.new

--- a/source/spec/vagrant-openstack-provider/command/flavor_list_spec.rb
+++ b/source/spec/vagrant-openstack-provider/command/flavor_list_spec.rb
@@ -2,7 +2,6 @@ require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::Command::FlavorList do
   describe 'cmd' do
-
     let(:nova) do
       double('nova').tap do |nova|
         nova.stub(:get_all_flavors) do
@@ -15,7 +14,7 @@ describe VagrantPlugins::Openstack::Command::FlavorList do
     end
 
     let(:env) do
-      Hash.new.tap do |env|
+      {}.tap do |env|
         env[:ui] = double('ui')
         env[:ui].stub(:info).with(anything)
         env[:openstack_client] = double

--- a/source/spec/vagrant-openstack-provider/command/floatingip_list_spec.rb
+++ b/source/spec/vagrant-openstack-provider/command/floatingip_list_spec.rb
@@ -2,7 +2,6 @@ require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::Command::FloatingIpList do
   describe 'cmd' do
-
     let(:nova) do
       double('nova').tap do |nova|
         nova.stub(:get_floating_ip_pools) do
@@ -37,7 +36,7 @@ describe VagrantPlugins::Openstack::Command::FloatingIpList do
     end
 
     let(:env) do
-      Hash.new.tap do |env|
+      {}.tap do |env|
         env[:ui] = double('ui')
         env[:ui].stub(:info).with(anything)
         env[:openstack_client] = double

--- a/source/spec/vagrant-openstack-provider/command/image_list_spec.rb
+++ b/source/spec/vagrant-openstack-provider/command/image_list_spec.rb
@@ -1,7 +1,6 @@
 require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::Command::ImageList do
-
   let(:nova) do
     double('nova').tap do |nova|
       nova.stub(:get_all_images) do
@@ -27,7 +26,7 @@ describe VagrantPlugins::Openstack::Command::ImageList do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:ui] = double('ui')
       env[:ui].stub(:info).with(anything)
       env[:openstack_client] = double
@@ -42,7 +41,6 @@ describe VagrantPlugins::Openstack::Command::ImageList do
 
   describe 'cmd' do
     context 'when glance is not available' do
-
       let(:session) do
         double('session').tap do |s|
           s.stub(:endpoints) { {} }
@@ -50,7 +48,6 @@ describe VagrantPlugins::Openstack::Command::ImageList do
       end
 
       it 'prints image list with only the id and the name' do
-
         env[:openstack_client].stub(:session) { session }
         allow(@image_list_cmd).to receive(:with_target_vms).and_return(nil)
         nova.should_receive(:get_all_images).with(env)
@@ -68,7 +65,6 @@ describe VagrantPlugins::Openstack::Command::ImageList do
     end
 
     context 'when glance is available' do
-
       let(:session) do
         double('session').tap do |s|
           s.stub(:endpoints) do
@@ -80,7 +76,6 @@ describe VagrantPlugins::Openstack::Command::ImageList do
       end
 
       it 'prints image list with id, name and details' do
-
         env[:openstack_client].stub(:session) { session }
         allow(@image_list_cmd).to receive(:with_target_vms).and_return(nil)
         glance.should_receive(:get_all_images).with(env)

--- a/source/spec/vagrant-openstack-provider/command/network_list_spec.rb
+++ b/source/spec/vagrant-openstack-provider/command/network_list_spec.rb
@@ -2,7 +2,6 @@ require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::Command::NetworkList do
   describe 'cmd' do
-
     let(:neutron) do
       double('neutron').tap do |neutron|
         neutron.stub(:get_private_networks) do
@@ -22,7 +21,7 @@ describe VagrantPlugins::Openstack::Command::NetworkList do
     end
 
     let(:env) do
-      Hash.new.tap do |env|
+      {}.tap do |env|
         env[:ui] = double('ui')
         env[:ui].stub(:info).with(anything)
         env[:openstack_client] = double
@@ -62,6 +61,5 @@ describe VagrantPlugins::Openstack::Command::NetworkList do
 
       @network_list_cmd.cmd('network-list', ['all'], env)
     end
-
   end
 end

--- a/source/spec/vagrant-openstack-provider/command/reset_spec.rb
+++ b/source/spec/vagrant-openstack-provider/command/reset_spec.rb
@@ -2,9 +2,8 @@ require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::Command::Reset do
   describe 'cmd' do
-
     let(:env) do
-      Hash.new.tap do |env|
+      {}.tap do |env|
         env[:ui] = double('ui')
         env[:ui].stub(:info).with(anything)
         env[:machine] = double('machine')

--- a/source/spec/vagrant-openstack-provider/command/subnet_list_spec.rb
+++ b/source/spec/vagrant-openstack-provider/command/subnet_list_spec.rb
@@ -2,7 +2,6 @@ require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::Command::SubnetList do
   describe 'cmd' do
-
     let(:neutron) do
       double('neutron').tap do |neutron|
         neutron.stub(:get_subnets) do
@@ -16,7 +15,7 @@ describe VagrantPlugins::Openstack::Command::SubnetList do
     end
 
     let(:env) do
-      Hash.new.tap do |env|
+      {}.tap do |env|
         env[:ui] = double('ui')
         env[:ui].stub(:info).with(anything)
         env[:openstack_client] = double

--- a/source/spec/vagrant-openstack-provider/command/volume_list_spec.rb
+++ b/source/spec/vagrant-openstack-provider/command/volume_list_spec.rb
@@ -2,7 +2,6 @@ require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::Command::VolumeList do
   describe 'cmd' do
-
     let(:cinder) do
       double('cinder').tap do |cinder|
         cinder.stub(:get_all_volumes) do
@@ -13,7 +12,7 @@ describe VagrantPlugins::Openstack::Command::VolumeList do
     end
 
     let(:env) do
-      Hash.new.tap do |env|
+      {}.tap do |env|
         env[:ui] = double('ui')
         env[:ui].stub(:info).with(anything)
         env[:openstack_client] = double

--- a/source/spec/vagrant-openstack-provider/config_resolver_spec.rb
+++ b/source/spec/vagrant-openstack-provider/config_resolver_spec.rb
@@ -1,7 +1,6 @@
 require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::ConfigResolver do
-
   let(:config) do
     double('config').tap do |config|
       config.stub(:tenant_name) { 'testTenant' }
@@ -75,7 +74,7 @@ describe VagrantPlugins::Openstack::ConfigResolver do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:ui] = double('ui')
       env[:ui].stub(:info).with(anything)
       env[:machine] = double('machine')
@@ -400,7 +399,6 @@ describe VagrantPlugins::Openstack::ConfigResolver do
     context 'neutron service is available' do
       context 'with network configured in all possible ways' do
         it 'returns normalized network list' do
-
           config.stub(:networks) do
             ['001',
              'net-02',
@@ -653,7 +651,6 @@ describe VagrantPlugins::Openstack::ConfigResolver do
     context 'cinder service is available' do
       context 'with volume attached in all possible ways' do
         it 'returns normalized volume list' do
-
           config.stub(:volumes) do
             ['001',
              'vol-02',

--- a/source/spec/vagrant-openstack-provider/config_resolver_spec.rb
+++ b/source/spec/vagrant-openstack-provider/config_resolver_spec.rb
@@ -647,7 +647,7 @@ describe VagrantPlugins::Openstack::ConfigResolver do
       end
 
       context 'with hash containing an image_name with a size' do
-        it 'return nomalized volume' do
+        it 'return normalized volume' do
           config.stub(:volume_boot) { { image: 'image-01', size: '10' } }
           nova.stub(:get_all_images).with(anything) do
             [Item.new('img-001', 'image-01'),
@@ -658,7 +658,7 @@ describe VagrantPlugins::Openstack::ConfigResolver do
       end
 
       context 'with hash containing an image_name, size, device and delete_on_destroy' do
-        it 'return nomalized volume' do
+        it 'return normalized volume' do
           config.stub(:volume_boot) { { image: 'image-01', size: '10', device: 'vdb', delete_on_destroy: 'false' } }
           nova.stub(:get_all_images).with(anything) do
             [Item.new('img-001', 'image-01'),

--- a/source/spec/vagrant-openstack-provider/config_spec.rb
+++ b/source/spec/vagrant-openstack-provider/config_spec.rb
@@ -5,9 +5,7 @@ describe VagrantPlugins::Openstack::Config do
     let(:vagrant_public_key) { Vagrant.source_root.join('keys/vagrant.pub') }
 
     subject do
-      super().tap do |o|
-        o.finalize!
-      end
+      super().tap(&:finalize!)
     end
 
     its(:password)  { should be_nil }
@@ -253,9 +251,7 @@ describe VagrantPlugins::Openstack::Config do
     end
 
     subject do
-      super().tap do |o|
-        o.finalize!
-      end
+      super().tap(&:finalize!)
     end
 
     context 'with invalid stack' do

--- a/source/spec/vagrant-openstack-provider/e2e_spec.rb.save
+++ b/source/spec/vagrant-openstack-provider/e2e_spec.rb.save
@@ -1,0 +1,27 @@
+require 'vagrant-openstack-provider/spec_helper'
+
+require 'aruba'
+require 'aruba/api'
+
+include Aruba::Api
+
+# spec/template_spec.rb
+require 'pathname'
+
+root = Pathname.new(__FILE__).parent.parent
+
+# Allows us to run commands directly, without worrying about the CWD
+ENV['PATH'] = "#{root.join('bin').to_s}#{File::PATH_SEPARATOR}#{ENV['PATH']}"
+
+describe "genud" do
+  context "YAML templates" do
+    it "should emit valid YAML to STDOUT", :focus do
+
+      puts '#####################'
+      # Run the command with Aruba's run_simple helper
+      run_simple "bundle exec vagrant openstack", false, 10
+
+#      assert_exit_status(0)
+    end
+  end
+end

--- a/source/spec/vagrant-openstack-provider/spec_helper.rb
+++ b/source/spec/vagrant-openstack-provider/spec_helper.rb
@@ -12,6 +12,7 @@ if ENV['COVERAGE'] != 'false'
 end
 
 Dir[
+  'lib/vagrant-openstack-provider/version_checker.rb',
   'lib/vagrant-openstack-provider/logging.rb',
   'lib/vagrant-openstack-provider/config.rb',
   'lib/vagrant-openstack-provider/config_resolver.rb',

--- a/source/spec/vagrant-openstack-provider/utils_spec.rb
+++ b/source/spec/vagrant-openstack-provider/utils_spec.rb
@@ -1,7 +1,6 @@
 require 'vagrant-openstack-provider/spec_helper'
 
 describe VagrantPlugins::Openstack::Utils do
-
   let(:config) do
     double('config').tap do |config|
       config.stub(:tenant_name) { 'testTenant' }
@@ -19,7 +18,7 @@ describe VagrantPlugins::Openstack::Utils do
   end
 
   let(:env) do
-    Hash.new.tap do |env|
+    {}.tap do |env|
       env[:machine] = double('machine')
       env[:machine].stub(:provider_config) { config }
       env[:machine].stub(:id) { '1234id' }

--- a/source/spec/vagrant-openstack-provider/version_checker_spec.rb
+++ b/source/spec/vagrant-openstack-provider/version_checker_spec.rb
@@ -1,0 +1,39 @@
+require 'vagrant-openstack-provider/spec_helper'
+
+describe VagrantPlugins::Openstack::VersionChecker do
+  let(:version) do
+    double('version')
+  end
+
+  before :each do
+    @checker = VersionChecker.instance
+    @checker.status = nil
+    Gem.should_receive(:latest_spec_for)
+      .with('vagrant-openstack-provider')
+      .and_return(OpenStruct.new.tap { |v| v.version = version })
+  end
+
+  describe 'check' do
+    it { assert_version_is :latest,          '1.2.3',        '1.2.3' }
+    it { assert_version_is :latest,    '999.999.999',  '999.999.999' }
+    it { assert_version_is :unstable, '9999.999.999', '9999.999.999' }
+    it { assert_version_is :unstable, '999.9999.999', '999.9999.999' }
+    it { assert_version_is :unstable, '999.999.9999', '999.999.9999' }
+    it { assert_version_is :unstable,          '1.2',          '1.2' }
+    it { assert_version_is :outdated,        '1.2.3',        '1.2.2' }
+    it { assert_version_is :outdated,      '1.8.999',      '1.8.998' }
+    it { assert_version_is :outdated,        '1.9.0',      '1.8.999' }
+    it { assert_version_is :outdated,        '2.0.0',    '1.999.999' }
+  end
+
+  private
+
+  def assert_version_is(expected_status, latest, current)
+    stub_const('VagrantPlugins::Openstack::VERSION', current)
+    version.stub(:version) { latest }
+    @checker.stub(:print)
+    expect(@checker).to receive(:print) unless expected_status == :latest
+    @checker.check
+    expect(@checker.status).to eq(expected_status)
+  end
+end


### PR DESCRIPTION
Feature tested on prod Numergy.

- refacto method resolve_image: Now called to retrieve image_id and volume_boot/image_id
- update resolve_volume for returning { id: id, image: image: device: device, size: size, delete_on_destroy: delete_on_destroy}

NB: A possible improvement could be to not return a key/value when the value is null.
 