### PR TITLE
Stop hardcoding excluded paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,8 +255,11 @@ If neither `keypair_name` nor `public_key_path` are set, vagrant will generate a
   include rsync, you must set this parameter to "none".
 * `rsync_includes` - If `sync_method` is set to "rsync", this parameter give the list of local folders to sync
   on the remote VM.
-* `rsync_ignore_files` - Is used for the rsync prameter "--exclude-from".  Set `rsync_ignore_files` to a list of files
-  that contain patterns to exclude from the rsync to /vagrant on a provisioned instance.  ".gitignore  or ".hgignore" for example.
+* `rsync_ignore_files` - Is used for the rsync parameter "--exclude-from".  Set `rsync_ignore_files` to a list of files
+  that contain patterns to exclude from the rsync to /vagrant on a provisioned instance.  ".gitignore"  or ".hgignore" for example.
+* `rsync_exclude_paths` - Is used for the rsync parameter "--exclude".  Set `rsync_exclude_paths` to a list of paths
+  to exclude from the rsync to /vagrant on a provisioned instance.  Default is []
+* `rsync_cvs_exclude - Is used for the rsync parameter "--cvs-exclude". Set false to sync normally excluded CVS paths.
 
 There is minimal support for synced folders. Upon `vagrant up`,
 `vagrant reload`, and `vagrant provision`, the OpenStack provider will use

--- a/source/lib/vagrant-openstack-provider/action/sync_folders.rb
+++ b/source/lib/vagrant-openstack-provider/action/sync_folders.rb
@@ -87,15 +87,22 @@ module VagrantPlugins
             # --cvs-exclude
             command = [
               'rsync', '--verbose', '--archive', '-z',
-              '--cvs-exclude',
-              '--exclude', '.hg/',
-              '--exclude', '.git/',
               '--chmod', 'ugo=rwX',
               *includes,
               '-e', "ssh -p #{ssh_info[:port]} -o StrictHostKeyChecking=no #{ssh_key_options(ssh_info)}",
               hostpath,
               "#{ssh_info[:username]}@#{ssh_info[:host]}:#{guestpath}"]
             command.compact!
+
+            if env[:machine].provider_config.rsync_cvs_exclude
+              command += ['--cvs-exclude']
+            end
+
+            exclude_paths = []
+            exclude_paths = env[:machine].provider_config.rsync_exclude_paths unless env[:machine].provider_config.rsync_exclude_paths.nil?
+            exclude_paths.each do |exclude_path|
+              command += ['--exclude', exclude_path]
+            end
 
             # during rsync, ignore files specified in list of files containing exclude patterns
             # ex: rsync_ignore_files = ['.hgignore', '.gitignore']

--- a/source/lib/vagrant-openstack-provider/config.rb
+++ b/source/lib/vagrant-openstack-provider/config.rb
@@ -111,6 +111,16 @@ module VagrantPlugins
       # @return [Array]
       attr_accessor :rsync_ignore_files
 
+      # Sync folder ignore paths. A list of paths to ignore in the rsync operation performed by this provider
+      #
+      # @return [Array]
+      attr_accessor :rsync_exclude_paths
+
+      # Sync folder ignore CVS excludes. A boolean flag to control the --cvs-exclude option for rsync. Default: true.
+      #
+      # @return [Boolean]
+      attr_accessor :rsync_cvs_exclude
+
       # Network list the VM will be connected to
       #
       # @return [Array]
@@ -212,6 +222,8 @@ module VagrantPlugins
         @username = UNSET_VALUE
         @rsync_includes = []
         @rsync_ignore_files = []
+        @rsync_exclude_paths = []
+        @rsync_cvs_exclude = UNSET_VALUE
         @keypair_name = UNSET_VALUE
         @ssh_username = UNSET_VALUE
         @ssh_timeout = UNSET_VALUE
@@ -258,7 +270,7 @@ module VagrantPlugins
             # Don't set the value if it is the unset value, either.
             value = obj.instance_variable_get(key)
 
-            if [:@networks, :@volumes, :@rsync_includes, :@rsync_ignore_files, :@floating_ip_pool, :@stacks].include? key
+            if [:@networks, :@volumes, :@rsync_includes, :@rsync_ignore_files, :@rsync_exclude_paths, :@floating_ip_pool, :@stacks].include? key
               result.instance_variable_set(key, value) unless value.empty?
             elsif [:@http].include? key
               result.instance_variable_set(key, instance_variable_get(key).merge(other.instance_variable_get(key))) if value != UNSET_VALUE
@@ -295,6 +307,8 @@ module VagrantPlugins
         @username = nil if @username == UNSET_VALUE
         @rsync_includes = nil if @rsync_includes.empty?
         @rsync_ignore_files = nil if @rsync_ignore_files.empty?
+        @rsync_exclude_paths = nil if @rsync_exclude_paths == UNSET_VALUE
+        @rsync_cvs_exclude = true if @rsync_exclude_paths == UNSET_VALUE
         @floating_ip = nil if @floating_ip == UNSET_VALUE
         @floating_ip_pool = nil if @floating_ip_pool == UNSET_VALUE
         @floating_ip_pool_always_allocate = false if floating_ip_pool_always_allocate == UNSET_VALUE


### PR DESCRIPTION
For many use cases excluding .git or .hg from the synced /vagrant
folder is a non-starter.  Therefore, allow a user to override this
functionality with 'rsync_exclude_paths' and 'rsync_cvs_exclude'
configuration options.

'rsync_exclude_paths' allows a user to set a list of paths to exclude
during rsync vis the --exclude rsync parameter.

'rsync_cvs_exclude' makes the --cvs-exclude option to rsync optional.
Currently, rsync already includes '.git' and '.hg' so there is no need
to call those our separately from --cvs-exclude.
