### PR TITLE
modified scheduler_hints hash key from 'scheduler_hints'

### DIFF
--- a/source/lib/vagrant-openstack-provider/client/nova.rb
+++ b/source/lib/vagrant-openstack-provider/client/nova.rb
@@ -73,7 +73,7 @@ module VagrantPlugins
           s['networks'] = options[:networks] unless options[:networks].nil? || options[:networks].empty?
         end
         object = { server: server }
-        object[:scheduler_hints] = options[:scheduler_hints] unless options[:scheduler_hints].nil?
+        object['os:scheduler_hints'] = options[:scheduler_hints] unless options[:scheduler_hints].nil?
         server = post(env, "#{@session.endpoints[:compute]}/servers", object.to_json)
         JSON.parse(server)['server']['id']
       end

--- a/source/spec/vagrant-openstack-provider/client/nova_spec.rb
+++ b/source/spec/vagrant-openstack-provider/client/nova_spec.rb
@@ -148,7 +148,7 @@ describe VagrantPlugins::Openstack::NovaClient do
             .with(
               body: '{"server":{"name":"inst","imageRef":"img","flavorRef":"flav","key_name":"key",'\
               '"security_groups":[{"name":"default"}],"user_data":"dXNlcl9kYXRhX3Rlc3Q=\n","metadata":"metadata_test"},'\
-              '"scheduler_hints":"sched_hints_test"}',
+              '"os:scheduler_hints":"sched_hints_test"}',
               headers:
               {
                 'Accept' => 'application/json',


### PR DESCRIPTION
modified the scheduler_hints json tag produced when creating a server by changing the hash key used in the options dictionary.  Updated client/nova and corresponding spec

Fixes #231