### PR TITLE
Ruby 2.2 and json 1.7.7 are incompatible

### DIFF
--- a/source/vagrant-openstack-provider.gemspec
+++ b/source/vagrant-openstack-provider.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/ggiamarchi/vagrant-openstack-provider'
   gem.license       = 'MIT'
 
-  gem.add_dependency 'json', '1.7.7'
+  gem.add_dependency 'json', '1.8.3'
   gem.add_dependency 'rest-client', '~> 1.6.0'
   gem.add_dependency 'terminal-table', '1.4.5'
   gem.add_dependency 'sshkey', '1.6.1'


### PR DESCRIPTION
People with ruby 2.2 can not build json 1.7.7

```
An error occurred while installing json (1.7.7), and Bundler cannot continue.
Make sure that `gem install json -v '1.7.7'` succeeds before bundling.

Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    /usr/bin/ruby -r ./siteconf20150707-16067-1fjctt.rb extconf.rb
creating Makefile

make "DESTDIR=" clean
rm -f
rm -f generator.so  *.o  *.bak mkmf.log .*.time

make "DESTDIR="
gcc -I. -I/usr/include -I/usr/include/ruby/backward -I/usr/include -I. -DJSON_GENERATOR    -fPIC -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -mtune=generic -fPIC -O3 -Wall -O0 -ggdb -m64 -o generator.o -c generator.c
In file included from /usr/include/stdio.h:27:0,
                 from /usr/include/ruby/defines.h:26,
                 from /usr/include/ruby/ruby.h:29,
                 from /usr/include/ruby.h:33,
                 from ../fbuffer/fbuffer.h:5,
                 from generator.c:1:
/usr/include/features.h:328:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
 #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
    ^
In file included from generator.c:1:0:
../fbuffer/fbuffer.h: In function ‘fbuffer_to_s’:
../fbuffer/fbuffer.h:175:47: error: macro "rb_str_new" requires 2 arguments, but only 1 given
     VALUE result = rb_str_new(FBUFFER_PAIR(fb));
                                               ^
../fbuffer/fbuffer.h:175:20: warning: initialization makes integer from pointer without a cast [-Wint-conversion]
     VALUE result = rb_str_new(FBUFFER_PAIR(fb));
                    ^
Makefile:238: recipe for target 'generator.o' failed
make: *** [generator.o] Error 1

make failed, exit code 2
```

And so vagrant plugin install vagrant-openstack-provider falls back to
version 0.3.2. I just bump to json version 1.8.3, which is ruby 2.2
compatible.