### PR TITLE
Get shell provisioner class from plugin manager

### DIFF
--- a/source/lib/vagrant-openstack-provider/action/provision.rb
+++ b/source/lib/vagrant-openstack-provider/action/provision.rb
@@ -31,7 +31,7 @@ module VagrantPlugins
         end
 
         def run_provisioner(env)
-          if env[:provisioner].class == VagrantPlugins::Shell::Provisioner
+          if env[:provisioner].is_a?(Vagrant.plugin('2').manager.provisioners[:shell])
             handle_shell_meta_args(env)
           end
           env[:provisioner].provision

--- a/source/spec/vagrant-openstack-provider/action/provision_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/provision_spec.rb
@@ -17,17 +17,6 @@ class FakeShellProvisioner < FakeProvisioner
   end
 end
 
-#
-# Monkeypatch the VagrantPlugins::Shell module
-# to enabled using an FakeShellProvisioner in
-# place of a the real shell provisioner class
-#
-module VagrantPlugins
-  module Shell
-    Provisioner = FakeShellProvisioner
-  end
-end
-
 describe VagrantPlugins::Openstack::Action::ProvisionWrapper do
   let(:app) do
     double
@@ -38,6 +27,8 @@ describe VagrantPlugins::Openstack::Action::ProvisionWrapper do
   end
 
   before :each do
+    # Stub lookup for provisioners and return a hash containing the test mock.
+    allow(Vagrant.plugin('2').manager).to receive(:provisioners).and_return(shell: FakeShellProvisioner)
     @action = ProvisionWrapper.new(app, nil)
   end
 
@@ -57,6 +48,8 @@ describe VagrantPlugins::Openstack::Action::InternalProvisionWrapper do
   end
 
   before :each do
+    # Stub lookup for provisioners and return a hash containing the test mock.
+    allow(Vagrant.plugin('2').manager).to receive(:provisioners).and_return(shell: FakeShellProvisioner)
     @action = InternalProvisionWrapper.new(nil, env)
   end
 


### PR DESCRIPTION
Vagrant core tries very hard to be lazy and only loads plugin classes when
necessary. This caused a break in version 0.7.0 when a test was added to
the `provision` action to check if an object is of class
`VagrantPlugins::Shell::Provisioner`. The `vagrant up` action triggers a lazy
load of this class, while the `vagrant provsion` action does not.

This patch ensures the provisioner class is loaded by retrieving it through the
Vagrant plugin manager instead of using a direct reference.

Fixes ggiamarchi/vagrant-openstack-provider#240