### PR TITLE
Add .bundle to rubocop ignore list

### DIFF
--- a/source/.rubocop.yml
+++ b/source/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   Exclude:
+    - '.bundle/**/*'
     - 'out/**/*'
     - '**/Vagrantfile'
 


### PR DESCRIPTION
Add the `.bundle` directory, and all subdirectories to the ignore list for
Rubcop. This facilitates per-project sandboxing with `bundle install --path`.