### PR TITLE
Use only provided ssh key and don't touch the known_hosts

### DIFF
--- a/source/lib/vagrant-openstack-provider/action/sync_folders.rb
+++ b/source/lib/vagrant-openstack-provider/action/sync_folders.rb
@@ -82,6 +82,15 @@ module VagrantPlugins
               incls << incl
             end
 
+            # Create ssh params for rsync
+            # we need them as one string because rsync -e expects one string
+            ssh_params = [
+              "ssh -p #{ssh_info[:port]}",
+              '-o StrictHostKeyChecking=no',
+              '-o UserKnownHostsFile=/dev/null',
+              '-o IdentitiesOnly=yes',
+              "#{ssh_key_options(ssh_info)}"].join(' ')
+
             # Rsync over to the guest path using the SSH info. add
             # .hg/ and .git/ to exclude list as that isn't covered in
             # --cvs-exclude
@@ -92,7 +101,7 @@ module VagrantPlugins
               '--exclude', '.git/',
               '--chmod', 'ugo=rwX',
               *includes,
-              '-e', "ssh -p #{ssh_info[:port]} -o StrictHostKeyChecking=no #{ssh_key_options(ssh_info)}",
+              '-e', ssh_params,
               hostpath,
               "#{ssh_info[:username]}@#{ssh_info[:host]}:#{guestpath}"]
             command.compact!

--- a/source/spec/vagrant-openstack-provider/action/sync_folders_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/sync_folders_spec.rb
@@ -111,7 +111,7 @@ describe VagrantPlugins::Openstack::Action::SyncFolders do
                             '--chmod',
                             'ugo=rwX',
                             '-e',
-                            "ssh -p 23 -o StrictHostKeyChecking=no -i '/tmp/key.pem' ",
+                            "ssh -p 23 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -i '/tmp/key.pem' ",
                             '/home/john/vagrant/',
                             'user@1.2.3.4:/vagrant',
                             '--exclude-from',


### PR DESCRIPTION
In setups with ssh-agent with >=6 keys rsync runs into authentication
failures as it tries the agent keys first and then the provided key.
Because of default MaxAuthTries=6 in sshd_config the provided key isn't
reached and there is an authentication error

This change is aligned with vagrant ssh handling:
https://github.com/mitchellh/vagrant/blob/b721eb62cfbfa93895d0d4cf019436ab6b1df05d/lib/vagrant/util/ssh.rb#L108-L121