### PR TITLE
Fix heat stack create when multiple machines are declared

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ test/version_tmp
 tmp
 .venv
 .idea/
+*.swp

--- a/samples/04_heat_stack/Vagrantfile
+++ b/samples/04_heat_stack/Vagrantfile
@@ -1,0 +1,33 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure('2') do |config|
+
+  config.vm.provider :openstack do |os|
+    os.openstack_auth_url    = ENV['OS_AUTH_URL']
+    os.tenant_name           = ENV['OS_TENANT_NAME']
+    os.username              = ENV['OS_USERNAME']
+    os.password              = ENV['OS_PASSWORD']
+    os.floating_ip_pool      = ENV['OS_FLOATING_IP_POOL']
+    os.flavor                = ENV['OS_FLAVOR']
+    os.image                 = ENV['OS_IMAGE']
+    os.security_groups       = ['sg']
+    os.networks             << 'net'
+    os.stacks               << {name: 'vagrant',
+				template: "#{File.dirname(__FILE__)}/stack.yml"}
+  end
+
+  config.vm.define 'server-1' do |s|
+    s.vm.provider :openstack do |os, override|
+      os.server_name = 'server-1'
+      override.ssh.username = ENV['OS_SSH_USERNAME']
+    end
+  end
+
+  config.vm.define 'server-2' do |s|
+    s.vm.provider :openstack do |os, override|
+      os.server_name = 'server-2'
+      override.ssh.username = ENV['OS_SSH_USERNAME']
+    end
+  end
+end

--- a/samples/04_heat_stack/stack.yml
+++ b/samples/04_heat_stack/stack.yml
@@ -1,0 +1,52 @@
+heat_template_version: 2013-05-23
+
+description: >
+    Create a minimal infrastructure to spawn an instance
+
+parameters:
+
+  external_network_id:
+    type: string
+    label: External network id
+    description: External network to connect the router
+    default: 3251e134-4045-44a0-9578-f6eb5ea21a87
+
+resources:
+
+  security_group:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      name: sg
+      description: Add security group rules for server
+      rules:
+        - remote_ip_prefix: 0.0.0.0/0
+          direction: ingress
+        - remote_ip_prefix: 0.0.0.0/0
+          direction: egress
+
+  network:
+    type: OS::Neutron::Net
+    properties:
+      name: net
+  subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network_id: { get_resource: network }
+      cidr: 10.0.0.0/24
+      allocation_pools:
+        - { start: 10.0.0.100, end: 10.0.0.250 }
+
+  router:
+    type: OS::Neutron::Router
+    properties:
+      name: router
+  router-gateway:
+    type: OS::Neutron::RouterGateway
+    properties:
+      router_id: { get_resource: router }
+      network_id: { get_param: external_network_id }
+  router-dataplane-int:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router_id: { get_resource: router }
+      subnet_id: { get_resource: subnet }

--- a/source/.rubocop.yml
+++ b/source/.rubocop.yml
@@ -13,6 +13,9 @@ Style/Encoding:
 Style/Documentation:
   Enabled: false
 
+Style/ClassVars:
+  Enabled: false
+
 Metrics/ClassLength:
   Max: 300
 

--- a/source/lib/vagrant-openstack-provider/action/create_stack.rb
+++ b/source/lib/vagrant-openstack-provider/action/create_stack.rb
@@ -13,12 +13,19 @@ module VagrantPlugins
   module Openstack
     module Action
       class CreateStack < AbstractAction
+        @@is_created = false
+
         def initialize(app, _env)
           @app = app
           @logger = Log4r::Logger.new('vagrant_openstack::action::create_stack')
         end
 
         def execute(env)
+          if @@is_created
+            @app.call(env)
+            return
+          end
+
           @logger.info 'Start create stacks action'
 
           config = env[:machine].provider_config
@@ -43,6 +50,7 @@ module VagrantPlugins
             waiting_for_stack_to_be_created(env, stack[:name], stack_id)
           end unless config.stacks.nil?
 
+          @@is_created = true
           @app.call(env)
         end
 


### PR DESCRIPTION
Vagrant launches the stack creation for each machine. Obviously, the second time fails because the stack already exists.

```
2015-11-23 14:25 | DEBUG | response => code    : 409
2015-11-23 14:25 | DEBUG | response => headers : {:content_type=>"application/json; charset=UTF-8", :content_length=>"214", :x_openstack_request_id=>"req-7f959980-42bf-47ae-a1e8-bacb464e4506", :date=>"Mon, 23 Nov 2015 13:25:44 GMT"}
2015-11-23 14:25 | DEBUG | response => body    : {"explanation": "There was a conflict when trying to complete your request.", "code": 409, "error": {"message": "The Stack (vagrant) already exists.", "traceback": null, "type": "StackExists"}, "title": "Conflict"}
```

This patch avoid to run the stack creation multiple times. Now the stack creation is run only once before the first machine creation.