### PR TITLE
Possible fix for #255 by adding a regex for both fixed as floating type

### DIFF
--- a/source/lib/vagrant-openstack-provider/utils.rb
+++ b/source/lib/vagrant-openstack-provider/utils.rb
@@ -9,7 +9,7 @@ module VagrantPlugins
         addresses = env[:openstack_client].nova.get_server_details(env, env[:machine].id)['addresses']
         addresses.each do |_, network|
           network.each do |network_detail|
-            return network_detail['addr'] if network_detail['OS-EXT-IPS:type'] == 'floating'
+            return network_detail['addr'] if network_detail['OS-EXT-IPS:type']  =~ /(^floating$|^fixed$)/
           end
         end
         fail Errors::UnableToResolveIP if addresses.size == 0


### PR DESCRIPTION
I encountered an issue #255 when executing vagrant ssh to a vagrant openstack instance which is available through a fixed ip and not with a floating ip.

As a possible fix I wrote a regex which matched both on floating as fixed ip instead which did solve the issue in my case.

