### PR TITLE
Upgrade json version to latest

### DIFF
--- a/source/vagrant-openstack-provider.gemspec
+++ b/source/vagrant-openstack-provider.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/ggiamarchi/vagrant-openstack-provider'
   gem.license       = 'MIT'
 
-  gem.add_dependency 'json', '1.7.7'
+  gem.add_dependency 'json', '1.8.3'
   gem.add_dependency 'rest-client', '~> 1.6.0'
   gem.add_dependency 'terminal-table', '1.4.5'
   gem.add_dependency 'sshkey', '1.6.1'


### PR DESCRIPTION
I wanted to install this plugin with the latest Vagrant (v.1.8.1 when I went to https://www.vagrantup.com/downloads.html) but received errors when bundle tries installing the json gem v1.7.7.  So, I figured I'd try getting the install to work with the latest JSON gem.

To do this, I performed the following on an Ubuntu v14.04 VM with Ruby v2.2.2 (via RVM):
- Fork repo
- Clone repo to my box

        git clone https://github.com/dandunckelman/vagrant-openstack-provider.git
- Create topic branch

        cd vagrant-openstack-provider
        git checkout -b upgrade-json-dependency
- Setup Ruby environment (since I use RVM):

        cd source/
        echo "2.2.2" > .ruby-version
        echo "vagrant-openstack-provider" > .ruby-gemset
- Install specific bundler version (since the Vagrant v1.7.4 gem requires bundler (<= 1.10.5, >= 1.5.2))

        gem install bundler -v 1.10.5
- Install gems

        bundle
- Run tests

        bundle exec rake
- Build as a gem

        bundle exec rake build
- Install plugin from gem

        cd ../../my-vagrant-project/
        vagrant plugin install ../vagrant-openstack-provider/source/pkg/vagrant-openstack-provider-0.7.0.gem

Then the install worked as expected.  I assume that this would fix the following issues:  https://github.com/ggiamarchi/vagrant-openstack-provider/issues/265 & 
https://github.com/ggiamarchi/vagrant-openstack-provider/issues/266