### PR TITLE
Run provisioner cleanup when destroying VMs

### DIFF
--- a/source/lib/vagrant-openstack-provider/action.rb
+++ b/source/lib/vagrant-openstack-provider/action.rb
@@ -17,6 +17,7 @@ module VagrantPlugins
             if env[:machine_state_id] == :not_created
               b2.use Message, I18n.t('vagrant_openstack.not_created')
             else
+              b2.use(ProvisionerCleanup, :before)
               b2.use DeleteServer
               b2.use DeleteStack
             end


### PR DESCRIPTION
Vagrant v1.3.0 introduced the ability for provisioners to define cleanup tasks
that get run during VM destruction in order to clean up bits of global state.
This patch adds the ProvisionerCleanup task to the OpenStack destroy action.