### PR TITLE
Enable Vagrant box usage

### DIFF
--- a/source/lib/vagrant-openstack-provider/action.rb
+++ b/source/lib/vagrant-openstack-provider/action.rb
@@ -56,6 +56,7 @@ module VagrantPlugins
       # key.
       def self.action_read_state
         new_builder.tap do |b|
+          b.use HandleBox
           b.use ConfigValidate
           b.use ConnectOpenstack
           b.use ReadState
@@ -92,6 +93,7 @@ module VagrantPlugins
 
       def self.action_up
         new_builder.tap do |b|
+          b.use HandleBox
           b.use ConfigValidate
           b.use ConnectOpenstack
 


### PR DESCRIPTION
This patch adds a call to the built-in HandleBox action during action_up and
action_read_state. This will cause Vagrant boxes to be downloaded so that their
configuration will be merged prior to the ConfigValidate action.