### PR TITLE
Allow status and ssh to run without a lock

### DIFF
--- a/source/lib/vagrant-openstack-provider/provider.rb
+++ b/source/lib/vagrant-openstack-provider/provider.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
         # Run a custom action called "read_ssh_info" which does what it
         # says and puts the resulting SSH info into the `:machine_ssh_info`
         # key in the environment.
-        env = @machine.action('read_ssh_info')
+        env = @machine.action('read_ssh_info', lock: false)
         env[:machine_ssh_info]
       end
 
@@ -30,7 +30,7 @@ module VagrantPlugins
         # Run a custom action we define called "read_state" which does
         # what it says. It puts the state in the `:machine_state_id`
         # key in the environment.
-        env = @machine.action('read_state')
+        env = @machine.action('read_state', lock: false)
 
         state_id = env[:machine_state_id]
 


### PR DESCRIPTION
Prior to this patch long running operations, such as provisioners, would
prevent `vagrant status` or `vagrant ssh` from being run due to Vagrant
action locking. Attempting such actions would result in an error message. This
is inconvienant as shelling into a VM is a common debugging step in figuring
out why a provisioner is taking longer than usual.

Vagrant 1.7 introduced the ability to mark certain actions as not requireing a
lock. This patch adds `lock: false` to the `get_state` and `get_ssh_info` calls
which allows both `vagrant status` and `vagrant ssh` to function while a
long-running action is executing in another process. Vagrant 1.6 will ignore
the unknown `lock` option and fail as usual.