### PR TITLE
don't break get_ip_address if static IP is assigned

### DIFF
--- a/source/lib/vagrant-openstack-provider/utils.rb
+++ b/source/lib/vagrant-openstack-provider/utils.rb
@@ -16,7 +16,12 @@ module VagrantPlugins
         if addresses.size == 1
           net_addresses = addresses.first[1]
         else
-          net_addresses = addresses[env[:machine].provider_config.networks[0]]
+          first_network = env[:machine].provider_config.networks[0]
+          if first_network.is_a? String
+            net_addresses = addresses[first_network]
+          else
+            net_addresses = addresses[first_network[:name]]
+          end
         end
         fail Errors::UnableToResolveIP if net_addresses.size == 0
         net_addresses[0]['addr']


### PR DESCRIPTION
If the first network in the config specifies a static IP address,
then the key to look up in `addresses` is `network[:name]`, not the
bare network hash.
