### PR TITLE
Fix travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ matrix:
       env: VAGRANT_VERSION=v1.7.4 BUNDLER_VERSION=1.10.5
 
     - rvm: 2.2.3
-      env: VAGRANT_VERSION=v1.8.1 BUNDLER_VERSION=1.10.6
+      env: VAGRANT_VERSION=v1.8.5 BUNDLER_VERSION=1.12.5
 
 sudo: false

--- a/source/Gemfile
+++ b/source/Gemfile
@@ -4,6 +4,9 @@ gemspec
 
 group :development do
   gem 'vagrant', git: 'https://github.com/mitchellh/vagrant.git', tag: 'v1.8.5'
+  # FIXME: Hack to allow Vagrant v1.6.5 to install for tests. Remove when
+  # support for 1.6.5 is dropped.
+  gem 'rack', '< 2'
   gem 'appraisal', '1.0.0'
   gem 'rubocop', '0.29.0', require: false
   gem 'coveralls', require: false

--- a/source/Gemfile
+++ b/source/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'vagrant', git: 'https://github.com/mitchellh/vagrant.git', tag: 'v1.8.1'
+  gem 'vagrant', git: 'https://github.com/mitchellh/vagrant.git', tag: 'v1.8.5'
   gem 'appraisal', '1.0.0'
   gem 'rubocop', '0.29.0', require: false
   gem 'coveralls', require: false


### PR DESCRIPTION
This patchset updates the Vagrant version used during development to 1.8.5 and fixes failing Travis tests for Vagrant 1.6.5.