### PR TITLE
Switch to Vagrant SyncedFolders

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ cloud.
 * Attach Cinder volumes to the instances
 * Create and delete Heat Orchestration stacks
 * Support OpenStack regions
-* Minimal synced folder support via `rsync`
 * Custom sub-commands within Vagrant CLI to query OpenStack objects
 
 ## Usage
@@ -249,6 +248,22 @@ If neither `keypair_name` nor `public_key_path` are set, vagrant will generate a
    `false`.
 
 ### Synced folders
+
+**NOTE:** The settings in this section are deprecated. By default, the OpenStack provider will use standard [Vagrant Synced Folders](https://www.vagrantup.com/docs/synced-folders/basic_usage.html). Vagrant's [rsync options](https://www.vagrantup.com/docs/synced-folders/rsync.html) can be configured thusly:
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.provider :openstack do |provider, override|
+    override.vm.synced_folder '.', '/vagrant', type: 'rsync',
+      rsync__exclude: ['some/folder/to/exclude']
+  end
+end
+```
+
+Use of the settings described below will cause the OpenStack provider to fall
+back to a legacy Rsync implementation that has fewer features. A deprecation
+warning will also be printed.
+
 
 * `sync_method` - Specify the synchronization method for shared folder between the host and the remote VM.
   Currently, it can be "rsync" or "none". The default value is "rsync". If your OpenStack image does not

--- a/source/lib/vagrant-openstack-provider/action.rb
+++ b/source/lib/vagrant-openstack-provider/action.rb
@@ -39,7 +39,13 @@ module VagrantPlugins
               else
                 b2.use Provision
               end
-              b2.use SyncFolders
+              if env[:machine].provider_config.use_legacy_synced_folders
+                env[:machine].ui.warn I18n.t('vagrant_openstack.config.sync_folders_deprecated')
+                b2.use SyncFolders
+              else
+                # Standard Vagrant implementation.
+                b2.use SyncedFolders
+              end
             end
           end
         end
@@ -111,7 +117,15 @@ module VagrantPlugins
                   b2.use Provision
                 end
               end
-              b2.use SyncFolders
+
+              if env[:machine].provider_config.use_legacy_synced_folders
+                env[:machine].ui.warn I18n.t('vagrant_openstack.config.sync_folders_deprecated')
+                b2.use SyncFolders
+              else
+                # Standard Vagrant implementation.
+                b2.use SyncedFolders
+              end
+
               b2.use CreateStack
               b2.use CreateServer
               b2.use Message, I18n.t('vagrant_openstack.ssh_disabled_provisioning') if ssh_disabled

--- a/source/locales/en.yml
+++ b/source/locales/en.yml
@@ -138,6 +138,12 @@ en:
         to the standard vagrant configuration option `config.vm.boot_timeout`.
       invalid_value_for_parameter: |-
         Invalid value '%{value}' for parameter '%{parameter}'
+      sync_folders_deprecated: |-
+        The following configuration settings are deprecated and should be
+        removed: rsync_includes, rsync_ignore_files, sync_method. Using these
+        settings causes the OpenStack provider to fall back to an old synced
+        folder implementation instead of using standard Vagrant synced folders.
+
 
     errors:
       default: |-

--- a/source/spec/vagrant-openstack-provider/config_spec.rb
+++ b/source/spec/vagrant-openstack-provider/config_spec.rb
@@ -16,7 +16,10 @@ describe VagrantPlugins::Openstack::Config do
     its(:image)    { should be_nil }
     its(:server_name) { should be_nil }
     its(:username) { should be_nil }
+    its(:use_legacy_synced_folders) { should eq(false) }
     its(:rsync_includes) { should be_nil }
+    its(:rsync_ignore_files) { should be_nil }
+    its(:sync_method) { should be_nil }
     its(:keypair_name) { should be_nil }
     its(:public_key_path) { should be_nil }
     its(:availability_zone) { should be_nil }
@@ -55,11 +58,36 @@ describe VagrantPlugins::Openstack::Config do
       end
     end
 
+    describe 'use_legacy_synced_folders' do
+      it 'should default to true if sync_method is set' do
+        subject.sync_method = 'rsync'
+        subject.finalize!
+
+        expect(subject.use_legacy_synced_folders).to eq(true)
+      end
+
+      it 'should default to true if rsync_includes is non-empty' do
+        subject.rsync_includes = ['some/file']
+        subject.finalize!
+
+        expect(subject.use_legacy_synced_folders).to eq(true)
+      end
+
+      it 'should default to true if rsync_ignore_files is non-empty' do
+        subject.rsync_ignore_files = ['some/file']
+        subject.finalize!
+
+        expect(subject.use_legacy_synced_folders).to eq(true)
+      end
+    end
+
     it 'should not default rsync_includes if overridden' do
       inc = 'core'
       subject.send(:rsync_include, inc)
       subject.finalize!
-      subject.send(:rsync_includes).should include(inc)
+
+      expect(subject.rsync_includes).to include(inc)
+      expect(subject.use_legacy_synced_folders).to eq(true)
     end
   end
 


### PR DESCRIPTION
Vagrant 1.5 introduced a standard SyncedFolders middleware which can be re-used
by providers to implement things such as rsync support. This patch uses Vagrant
SyncedFolders as the default sync implementation instead of the legacy
SyncFolder implementation inherited from the Rackspace project.

The legacy implementation is retained for backwards compatibility and will be
used if any of the following provider options is set:
- rsync_includes
- rsync_ignore_files
- sync_method

A deprecation warning will be printed.
