### PR TITLE
Add snapshot support

### DIFF
--- a/source/.rubocop.yml
+++ b/source/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
     - '.bundle/**/*'
     - 'out/**/*'
     - '**/Vagrantfile'
+  DisplayCopNames: true
 
 Style/FileName:
   Enabled: false

--- a/source/lib/vagrant-openstack-provider/action.rb
+++ b/source/lib/vagrant-openstack-provider/action.rb
@@ -236,6 +236,20 @@ module VagrantPlugins
       # TODO: Remove the if guard when Vagrant 1.8.0 is the minimum version.
       # rubocop:disable IndentationWidth
       if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
+      def self.action_snapshot_delete
+        new_builder.tap do |b|
+          b.use ConfigValidate
+          b.use ConnectOpenstack
+          b.use Call, IsState, :not_created do |env, b2|
+            if env[:result]
+              b2.use Message, I18n.t('vagrant_openstack.not_created')
+            else
+              b2.use SnapshotDelete
+            end
+          end
+        end
+      end
+
       def self.action_snapshot_list
         new_builder.tap do |b|
           b.use ConfigValidate
@@ -287,6 +301,7 @@ module VagrantPlugins
       # TODO: Remove the if guard when Vagrant 1.8.0 is the minimum version.
       # rubocop:disable IndentationWidth
       if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
+      autoload :SnapshotDelete, action_root.join('snapshot_delete')
       autoload :SnapshotList, action_root.join('snapshot_list')
       autoload :SnapshotSave, action_root.join('snapshot_save')
       end

--- a/source/lib/vagrant-openstack-provider/action.rb
+++ b/source/lib/vagrant-openstack-provider/action.rb
@@ -264,6 +264,30 @@ module VagrantPlugins
         end
       end
 
+      def self.action_snapshot_restore
+        new_builder.tap do |b|
+          b.use ConfigValidate
+          b.use ConnectOpenstack
+          b.use Call, IsState, :not_created do |env, b2|
+            if env[:result]
+              b2.use Message, I18n.t('vagrant_openstack.not_created')
+              next
+            end
+
+            b2.use SnapshotRestore
+            b2.use WaitForServerToBeActive
+            b2.use WaitForCommunicator
+
+            b2.use Call, IsEnvSet, :snapshot_delete do |env2, b3|
+              # Used by vagrant push/pop
+              b3.use action_snapshot_delete if env2[:result]
+            end
+
+            b2.use action_provision
+          end
+        end
+      end
+
       def self.action_snapshot_save
         new_builder.tap do |b|
           b.use ConfigValidate
@@ -303,6 +327,7 @@ module VagrantPlugins
       if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
       autoload :SnapshotDelete, action_root.join('snapshot_delete')
       autoload :SnapshotList, action_root.join('snapshot_list')
+      autoload :SnapshotRestore, action_root.join('snapshot_restore')
       autoload :SnapshotSave, action_root.join('snapshot_save')
       end
       # rubocop:enable IndentationWidth

--- a/source/lib/vagrant-openstack-provider/action.rb
+++ b/source/lib/vagrant-openstack-provider/action.rb
@@ -18,6 +18,7 @@ module VagrantPlugins
               b2.use Message, I18n.t('vagrant_openstack.not_created')
             else
               b2.use(ProvisionerCleanup, :before)
+              b2.use SnapshotCleanup if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
               b2.use DeleteServer
               b2.use DeleteStack
             end
@@ -325,6 +326,7 @@ module VagrantPlugins
       # TODO: Remove the if guard when Vagrant 1.8.0 is the minimum version.
       # rubocop:disable IndentationWidth
       if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
+      autoload :SnapshotCleanup, action_root.join('snapshot_cleanup')
       autoload :SnapshotDelete, action_root.join('snapshot_delete')
       autoload :SnapshotList, action_root.join('snapshot_list')
       autoload :SnapshotRestore, action_root.join('snapshot_restore')

--- a/source/lib/vagrant-openstack-provider/action.rb
+++ b/source/lib/vagrant-openstack-provider/action.rb
@@ -249,6 +249,20 @@ module VagrantPlugins
           end
         end
       end
+
+      def self.action_snapshot_save
+        new_builder.tap do |b|
+          b.use ConfigValidate
+          b.use ConnectOpenstack
+          b.use Call, IsState, :not_created do |env, b2|
+            if env[:result]
+              b2.use Message, I18n.t('vagrant_openstack.not_created')
+            else
+              b2.use SnapshotSave
+            end
+          end
+        end
+      end
       end # Vagrant > 1.8.0 guard
       # rubocop:enable IndentationWidth
 
@@ -274,6 +288,7 @@ module VagrantPlugins
       # rubocop:disable IndentationWidth
       if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
       autoload :SnapshotList, action_root.join('snapshot_list')
+      autoload :SnapshotSave, action_root.join('snapshot_save')
       end
       # rubocop:enable IndentationWidth
 

--- a/source/lib/vagrant-openstack-provider/action.rb
+++ b/source/lib/vagrant-openstack-provider/action.rb
@@ -233,6 +233,25 @@ module VagrantPlugins
         end
       end
 
+      # TODO: Remove the if guard when Vagrant 1.8.0 is the minimum version.
+      # rubocop:disable IndentationWidth
+      if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
+      def self.action_snapshot_list
+        new_builder.tap do |b|
+          b.use ConfigValidate
+          b.use ConnectOpenstack
+          b.use Call, IsState, :not_created do |env, b2|
+            if env[:result]
+              b2.use Message, I18n.t('vagrant_openstack.not_created')
+            else
+              b2.use SnapshotList
+            end
+          end
+        end
+      end
+      end # Vagrant > 1.8.0 guard
+      # rubocop:enable IndentationWidth
+
       # The autoload farm
       action_root = Pathname.new(File.expand_path('../action', __FILE__))
       autoload :Message, action_root.join('message')
@@ -251,6 +270,12 @@ module VagrantPlugins
       autoload :ProvisionWrapper, action_root.join('provision')
       autoload :WaitForServerToStop, action_root.join('wait_stop')
       autoload :WaitForServerToBeActive, action_root.join('wait_active')
+      # TODO: Remove the if guard when Vagrant 1.8.0 is the minimum version.
+      # rubocop:disable IndentationWidth
+      if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
+      autoload :SnapshotList, action_root.join('snapshot_list')
+      end
+      # rubocop:enable IndentationWidth
 
       private
 

--- a/source/lib/vagrant-openstack-provider/action/snapshot_cleanup.rb
+++ b/source/lib/vagrant-openstack-provider/action/snapshot_cleanup.rb
@@ -1,0 +1,32 @@
+require 'vagrant-openstack-provider/action/abstract_action'
+
+module VagrantPlugins
+  module Openstack
+    module Action
+      class SnapshotCleanup < AbstractAction
+        def initialize(app, _env)
+          @app = app
+        end
+
+        def call(env)
+          nova = env[:openstack_client].nova
+          machine_snapshots = nova.list_snapshots(env, env[:machine].id)
+
+          snapshots_to_clean = machine_snapshots.select do |s|
+            s.metadata.key?('vagrant_snapshot')
+          end
+
+          @app.call env
+
+          unless snapshots_to_clean.empty?
+            env[:ui].info("Deleting Vagrant snapshots: #{snapshots_to_clean.map(&:name)}")
+          end
+
+          snapshots_to_clean.each do |s|
+            nova.delete_snapshot(env, s.id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/source/lib/vagrant-openstack-provider/action/snapshot_delete.rb
+++ b/source/lib/vagrant-openstack-provider/action/snapshot_delete.rb
@@ -1,0 +1,32 @@
+require 'vagrant-openstack-provider/action/abstract_action'
+
+module VagrantPlugins
+  module Openstack
+    module Action
+      class SnapshotDelete < AbstractAction
+        def initialize(app, _env)
+          @app = app
+        end
+
+        def call(env)
+          nova = env[:openstack_client].nova
+          machine_snapshots = nova.list_snapshots(env, env[:machine].id)
+
+          snapshot = machine_snapshots.find { |s| s.name == env[:snapshot_name] }
+
+          unless snapshot.nil?
+            env[:ui].info(I18n.t('vagrant.actions.vm.snapshot.deleting',
+                                 name: snapshot.name))
+
+            nova.delete_snapshot(env, snapshot.id)
+
+            env[:ui].info(I18n.t('vagrant.actions.vm.snapshot.deleted',
+                                 name: snapshot.name))
+          end
+
+          @app.call env
+        end
+      end
+    end
+  end
+end

--- a/source/lib/vagrant-openstack-provider/action/snapshot_list.rb
+++ b/source/lib/vagrant-openstack-provider/action/snapshot_list.rb
@@ -1,0 +1,22 @@
+require 'vagrant-openstack-provider/action/abstract_action'
+
+module VagrantPlugins
+  module Openstack
+    module Action
+      class SnapshotList < AbstractAction
+        def initialize(app, _env)
+          @app = app
+        end
+
+        def call(env)
+          nova = env[:openstack_client].nova
+          machine_snapshots = nova.list_snapshots(env, env[:machine].id)
+
+          env[:machine_snapshot_list] = machine_snapshots.map(&:name)
+
+          @app.call env
+        end
+      end
+    end
+  end
+end

--- a/source/lib/vagrant-openstack-provider/action/snapshot_restore.rb
+++ b/source/lib/vagrant-openstack-provider/action/snapshot_restore.rb
@@ -1,0 +1,29 @@
+require 'vagrant-openstack-provider/action/abstract_action'
+
+module VagrantPlugins
+  module Openstack
+    module Action
+      class SnapshotRestore < AbstractAction
+        def initialize(app, _env)
+          @app = app
+        end
+
+        def call(env)
+          nova = env[:openstack_client].nova
+          machine_snapshots = nova.list_snapshots(env, env[:machine].id)
+
+          snapshot = machine_snapshots.find { |s| s.name == env[:snapshot_name] }
+
+          unless snapshot.nil?
+            env[:ui].info(I18n.t('vagrant.actions.vm.snapshot.restoring',
+                                 name: snapshot.name))
+
+            nova.restore_snapshot(env, env[:machine].id, snapshot.id)
+          end
+
+          @app.call env
+        end
+      end
+    end
+  end
+end

--- a/source/lib/vagrant-openstack-provider/action/snapshot_save.rb
+++ b/source/lib/vagrant-openstack-provider/action/snapshot_save.rb
@@ -1,0 +1,51 @@
+require 'vagrant-openstack-provider/action/abstract_action'
+
+module VagrantPlugins
+  module Openstack
+    module Action
+      class SnapshotSave < AbstractAction
+        def initialize(app, _env, retry_interval = 3)
+          @app = app
+          @retry_interval = retry_interval
+        end
+
+        def call(env)
+          nova = env[:openstack_client].nova
+          config = env[:machine].provider_config
+
+          env[:ui].info(I18n.t('vagrant.actions.vm.snapshot.saving',
+                               name: env[:snapshot_name]))
+
+          nova.create_snapshot(
+            env,
+            env[:machine].id, env[:snapshot_name])
+
+          image = nova.list_snapshots(env, env[:machine].id).find { |i| i.name == env[:snapshot_name] }
+
+          timeout(config.server_create_timeout, Errors::Timeout) do
+            loop do
+              image_status = nova.get_image_details(env, image.id)
+
+              break if image_status['status'] == 'ACTIVE'
+
+              unless image_status['progress'].nil?
+                env[:ui].clear_line
+                env[:ui].report_progress(image_status['progress'], 100, false)
+              end
+
+              sleep @retry_interval
+            end
+          end
+
+          # Clear progress output.
+          env[:ui].clear_line
+
+          env[:ui].success(I18n.t('vagrant.actions.vm.snapshot.saved',
+                                  name: env[:snapshot_name]))
+
+          @app.call env
+        end
+      end
+    end
+  end
+end

--- a/source/lib/vagrant-openstack-provider/cap/snapshot_list.rb
+++ b/source/lib/vagrant-openstack-provider/cap/snapshot_list.rb
@@ -1,0 +1,15 @@
+module VagrantPlugins
+  module Openstack
+    module Cap
+      module SnapshotList
+        # Returns a list of the snapshots that are taken on this machine.
+        #
+        # @return [Array<String>]
+        def self.snapshot_list(machine)
+          env = machine.action(:snapshot_list, lock: false)
+          env[:machine_snapshot_list]
+        end
+      end
+    end
+  end
+end

--- a/source/lib/vagrant-openstack-provider/client/domain.rb
+++ b/source/lib/vagrant-openstack-provider/client/domain.rb
@@ -25,19 +25,23 @@ module VagrantPlugins
         attr_accessor :size
         attr_accessor :min_ram
         attr_accessor :min_disk
+        attr_accessor :metadata
 
-        def initialize(id, name, visibility = nil, size = nil, min_ram = nil, min_disk = nil)
+        # rubocop:disable Metrics/ParameterLists
+        def initialize(id, name, visibility = nil, size = nil, min_ram = nil, min_disk = nil, metadata = {})
           @visibility = visibility
           @size = size
           @min_ram = min_ram
           @min_disk = min_disk
+          @metadata = metadata
           super(id, name)
         end
+        # rubocop:enable Metrics/ParameterLists
 
         protected
 
         def state
-          [@id, @name, @visibility, @size, @min_ram, @min_disk]
+          [@id, @name, @visibility, @size, @min_ram, @min_disk, @metadata]
         end
       end
 

--- a/source/lib/vagrant-openstack-provider/client/nova.rb
+++ b/source/lib/vagrant-openstack-provider/client/nova.rb
@@ -43,8 +43,18 @@ module VagrantPlugins
       end
 
       def get_all_images(env, headers = {})
-        images_json = get(env, "#{@session.endpoints[:compute]}/images", headers)
-        JSON.parse(images_json)['images'].map { |fl| Image.new(fl['id'], fl['name'], 'unknown') }
+        images_json = get(env, "#{@session.endpoints[:compute]}/images/detail", headers)
+        JSON.parse(images_json)['images'].map do |fl|
+          Image.new(
+            fl['id'],
+            fl['name'],
+            'unknown',
+            nil,
+            fl['minRam'],
+            fl['minDisk'],
+            fl['metadata']
+          )
+        end
       end
 
       # Get detailed information about an image
@@ -208,7 +218,10 @@ module VagrantPlugins
           post(
             env,
             "#{@session.endpoints[:compute]}/servers/#{server_id}/action",
-            { createImage: { name: snapshot_name } }.to_json)
+            { createImage: {
+              name: snapshot_name,
+              metadata: { vagrant_snapshot: 'true' }
+            } }.to_json)
         end
       end
 

--- a/source/lib/vagrant-openstack-provider/client/nova.rb
+++ b/source/lib/vagrant-openstack-provider/client/nova.rb
@@ -224,6 +224,22 @@ module VagrantPlugins
           "#{@session.endpoints[:compute]}/images/#{snapshot_id}")
       end
 
+      # Restore a VM to an identified snapshot
+      #
+      # @param env [Hash] Vagrant action environment
+      # @param server_id [String] Server UUID
+      # @param snapshot_id [String] Snapshot UUID
+      #
+      # @return [void]
+      def restore_snapshot(env, server_id, snapshot_id)
+        instance_exists do
+          post(
+            env,
+            "#{@session.endpoints[:compute]}/servers/#{server_id}/action",
+            { rebuild: { imageRef: snapshot_id } }.to_json)
+        end
+      end
+
       private
 
       VM_STATES =

--- a/source/lib/vagrant-openstack-provider/client/nova.rb
+++ b/source/lib/vagrant-openstack-provider/client/nova.rb
@@ -47,6 +47,17 @@ module VagrantPlugins
         JSON.parse(images_json)['images'].map { |fl| Image.new(fl['id'], fl['name'], 'unknown') }
       end
 
+      # Get detailed information about an image
+      #
+      # @param env [Hash] Vagrant action environment
+      # @param image_id [String] Image UUID
+      #
+      # @return [Hash]
+      def get_image_details(env, image_id)
+        image_json = get(env, "#{@session.endpoints[:compute]}/images/#{image_id}")
+        JSON.parse(image_json)['image']
+      end
+
       def create_server(env, options)
         server = {}.tap do |s|
           s['name'] = options[:name]
@@ -183,6 +194,22 @@ module VagrantPlugins
       # @return [Array<VagrantPlugins::Openstack::Domain::Image>]
       def list_snapshots(env, server_id)
         get_all_images(env, params: { server: server_id })
+      end
+
+      # Create a named snapsot for a given VM
+      #
+      # @param env [Hash] Vagrant action environment
+      # @param server_id [String] Server UUID
+      # @param snapshot_name [String]
+      #
+      # @return [void]
+      def create_snapshot(env, server_id, snapshot_name)
+        instance_exists do
+          post(
+            env,
+            "#{@session.endpoints[:compute]}/servers/#{server_id}/action",
+            { createImage: { name: snapshot_name } }.to_json)
+        end
       end
 
       private

--- a/source/lib/vagrant-openstack-provider/client/nova.rb
+++ b/source/lib/vagrant-openstack-provider/client/nova.rb
@@ -42,8 +42,8 @@ module VagrantPlugins
         FloatingIP.new(floating_ip['ip'], floating_ip['pool'], floating_ip['instance_id'])
       end
 
-      def get_all_images(env)
-        images_json = get(env, "#{@session.endpoints[:compute]}/images")
+      def get_all_images(env, headers = {})
+        images_json = get(env, "#{@session.endpoints[:compute]}/images", headers)
         JSON.parse(images_json)['images'].map { |fl| Image.new(fl['id'], fl['name'], 'unknown') }
       end
 
@@ -173,6 +173,16 @@ module VagrantPlugins
                             }.to_json)
           JSON.parse(attachment)['volumeAttachment']
         end
+      end
+
+      # List snapshot images associated with a particular server
+      #
+      # @param env [Hash] Vagrant action environment
+      # @param server_id [String] Server UUID
+      #
+      # @return [Array<VagrantPlugins::Openstack::Domain::Image>]
+      def list_snapshots(env, server_id)
+        get_all_images(env, params: { server: server_id })
       end
 
       private

--- a/source/lib/vagrant-openstack-provider/client/nova.rb
+++ b/source/lib/vagrant-openstack-provider/client/nova.rb
@@ -212,6 +212,18 @@ module VagrantPlugins
         end
       end
 
+      # Delete an identified snapshot
+      #
+      # @param env [Hash] Vagrant action environment
+      # @param snapshot_id [String] Snapshot UUID
+      #
+      # @return [void]
+      def delete_snapshot(env, snapshot_id)
+        delete(
+          env,
+          "#{@session.endpoints[:compute]}/images/#{snapshot_id}")
+      end
+
       private
 
       VM_STATES =

--- a/source/lib/vagrant-openstack-provider/plugin.rb
+++ b/source/lib/vagrant-openstack-provider/plugin.rb
@@ -35,6 +35,16 @@ module VagrantPlugins
         Provider
       end
 
+      # TODO: Remove the if guard when Vagrant 1.8.0 is the minimum version.
+      # rubocop:disable IndentationWidth
+      if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
+      provider_capability('openstack', 'snapshot_list') do
+        require_relative 'cap/snapshot_list'
+        Cap::SnapshotList
+      end
+      end
+      # rubocop:enable IndentationWidth
+
       command('openstack') do
         Openstack.init_i18n
         Openstack.init_logging

--- a/source/spec/vagrant-openstack-provider/client/nova_spec.rb
+++ b/source/spec/vagrant-openstack-provider/client/nova_spec.rb
@@ -101,7 +101,7 @@ describe VagrantPlugins::Openstack::NovaClient do
   describe 'get_all_images' do
     context 'with token and project_id acquainted' do
       it 'returns all images' do
-        stub_request(:get, 'http://nova/a1b2c3/images')
+        stub_request(:get, 'http://nova/a1b2c3/images/detail')
           .with(
             headers:
             {
@@ -110,13 +110,14 @@ describe VagrantPlugins::Openstack::NovaClient do
             })
           .to_return(
             status: 200,
-            body: '{ "images": [ { "id": "i1", "name": "image1"}, { "id": "i2", "name": "image2"} ] }')
+            body: '{ "images": [ { "id": "i1", "name": "image1", "metadata": {"customVal1": 1}}, { "id": "i2", "name": "image2"} ] }')
 
         images = @nova_client.get_all_images(env)
 
         expect(images.length).to eq(2)
         expect(images[0].id).to eq('i1')
         expect(images[0].name).to eq('image1')
+        expect(images[0].metadata['customVal1']).to eq(1)
         expect(images[1].id).to eq('i2')
         expect(images[1].name).to eq('image2')
       end


### PR DESCRIPTION
This patchset adds provider actions required by the `vagrant snapshot` command introduced in Vagrant 1.8.0. The semantics of each action are modeled after the Virtualbox implementation:

https://github.com/mitchellh/vagrant/blob/v1.8.0/plugins/providers/virtualbox/action.rb#L230-L281

The actions make use of Vagrant UI strings introduced in 1.8.0 and are thus surrounded by guard statements to prevent them from being loaded by older Vagrant versions.
