### PR TITLE
Fix failing tests for Vagrant 1.8.5

### DIFF
--- a/source/Gemfile
+++ b/source/Gemfile
@@ -7,6 +7,10 @@ group :development do
   # FIXME: Hack to allow Vagrant v1.6.5 to install for tests. Remove when
   # support for 1.6.5 is dropped.
   gem 'rack', '< 2'
+  # FIXME: Version 1.4.0 of the ruby_dep gem added a constraint on the Ruby
+  # version being >=2.2.5. This pin to ruby_dep 1.3.1 can be removed when the
+  # next Vagrant version after 1.8.5 is released.
+  gem 'ruby_dep', '~> 1.3.1'
   gem 'appraisal', '1.0.0'
   gem 'rubocop', '0.29.0', require: false
   gem 'coveralls', require: false


### PR DESCRIPTION
Version 1.4.0 of the ruby_dep gem, which is a dependency of the listen gem
used by Vagrant, added a very pessimistic constraint that requires Ruby 2.2.5
or newer. This patch pins ruby_dep to 1.3.1.