### PR TITLE
Add support for proxies with rsync

### DIFF
--- a/source/lib/vagrant-openstack-provider/action/sync_folders.rb
+++ b/source/lib/vagrant-openstack-provider/action/sync_folders.rb
@@ -89,7 +89,8 @@ module VagrantPlugins
               '-o StrictHostKeyChecking=no',
               '-o UserKnownHostsFile=/dev/null',
               '-o IdentitiesOnly=yes',
-              "#{ssh_key_options(ssh_info)}"].join(' ')
+              "#{ssh_proxy_options(ssh_info)}",
+              "#{ssh_key_options(ssh_info)}"].reject(&:empty?).join(' ')
 
             # Rsync over to the guest path using the SSH info. add
             # .hg/ and .git/ to exclude list as that isn't covered in
@@ -125,6 +126,10 @@ module VagrantPlugins
         def ssh_key_options(ssh_info)
           # Ensure that `private_key_path` is an Array (for Vagrant < 1.4)
           Array(ssh_info[:private_key_path]).map { |path| "-i '#{path}' " }.join
+        end
+
+        def ssh_proxy_options(ssh_info)
+          ("-o ProxyCommand='#{ssh_info[:proxy_command]}'" unless ssh_info[:proxy_command].nil?).to_s
         end
 
         def add_cygdrive_prefix_to_path(hostpath)

--- a/source/spec/vagrant-openstack-provider/action/sync_folders_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/sync_folders_spec.rb
@@ -46,7 +46,8 @@ describe VagrantPlugins::Openstack::Action::SyncFolders do
           username: 'user',
           port: '23',
           host: '1.2.3.4',
-          private_key_path: '/tmp/key.pem'
+          private_key_path: '/tmp/key.pem',
+          proxy_command: 'myproxycommand myproxy.example.com 80 %h %p'
         }
         m.provider_config = provider_config
         m.config = double('config').tap do |c|
@@ -111,7 +112,8 @@ describe VagrantPlugins::Openstack::Action::SyncFolders do
                             '--chmod',
                             'ugo=rwX',
                             '-e',
-                            "ssh -p 23 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -i '/tmp/key.pem' ",
+                            'ssh -p 23 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes ' \
+                            "-o ProxyCommand='myproxycommand myproxy.example.com 80 %h %p' -i '/tmp/key.pem' ",
                             '/home/john/vagrant/',
                             'user@1.2.3.4:/vagrant',
                             '--exclude-from',


### PR DESCRIPTION
Use the proxy command specified in  `ssh.proxy_command` for rsync
Fixes #300 
