### PR TITLE
add identity version 3 keystone login

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,10 @@ This provider exposes quite a few provider-specific configuration options:
 
 * `username` - The username with which to access OpenStack.
 * `password` - The API key for accessing OpenStack.
+* `domain_name` - The domain name when using identity API version 3 of keystone
 * `tenant_name` - The OpenStack project name to work on
+* `project_name` - The OpenStack project name used in identity v3
+* `identity_api_version` - The identity version to use : 2 or 3. If not provided, vagrant will use 2 by default.
 * `region` - The OpenStack region to work on
 * `openstack_auth_url` - The endpoint to authenticate against.
 * `openstack_compute_url` - The compute service URL to hit. This is good for custom endpoints. If not provided, vagrant will try to get it from catalog endpoint.
@@ -96,6 +99,7 @@ This provider exposes quite a few provider-specific configuration options:
 * `openstack_volume_url` - The block storage URL to hit. This is good for custom endpoints. If not provided, vagrant will try to get it from catalog endpoint.
 * `openstack_image_url` - The image URL to hit. This is good for custom endpoints. If not provided, vagrant will try to get it from catalog endpoint.
 * `endpoint_type` - The endpoint type to use : publicURL, adminURL, internalURL. If not provided, vagrant will use publicURL by default.
+* `interface_type` - The endpoint type to use for identity v3: public, admin, internal. If not provided, vagrant will use public by default.
 
 ### VM Configuration
 

--- a/source/locales/en.yml
+++ b/source/locales/en.yml
@@ -143,7 +143,14 @@ en:
         removed: rsync_includes, rsync_ignore_files, sync_method. Using these
         settings causes the OpenStack provider to fall back to an old synced
         folder implementation instead of using standard Vagrant synced folders.
-
+      domain_required: |-
+        A domain is required when using identity API version 3
+      project_name_required: |-
+        A project name is required when using identity API version 3
+      invalid_interface_type: |-
+        Interface type must be public, admin or internal (if not provided, default is public)
+      invalid_api_version: |-
+        identity API verison must be 2 or 3 (if nto provided, default is 2)
 
     errors:
       default: |-


### PR DESCRIPTION
As stated in the header adding support for using v3 of keystone.

Added this configs to match env from openstack:
    os.project_name           = ENV['OS_PROJECT_NAME']
    os.domain_name            = ENV['OS_USER_DOMAIN_NAME']
    os.identity_api_version   = ENV['OS_IDENTITY_API_VERSION']
    os.interface_type           = "public"

identity_api_version is the default 2 if not set.
os.project_name is the old tenant name, but it changed name in the env so i did not want to reuse it.
Did the same with interface and endpoint.

Fixed #4 

Signed-off-by: Robert Marklund <robert.marklund@ericsson.com>