### PR TITLE
Fixed deprecation warning for "Object#timeout"

### DIFF
--- a/source/lib/vagrant-openstack-provider/action/create_server.rb
+++ b/source/lib/vagrant-openstack-provider/action/create_server.rb
@@ -131,7 +131,7 @@ module VagrantPlugins
           @logger.info "Waiting for the server with id #{server_id} to be built..."
           env[:ui].info(I18n.t('vagrant_openstack.waiting_for_build'))
           config = env[:machine].provider_config
-          timeout(config.server_create_timeout, Errors::Timeout) do
+          Timeout.timeout(config.server_create_timeout, Errors::Timeout) do
             server_status = 'WAITING'
             until server_status == 'ACTIVE'
               @logger.debug('Waiting for server to be ACTIVE')

--- a/source/lib/vagrant-openstack-provider/action/create_stack.rb
+++ b/source/lib/vagrant-openstack-provider/action/create_stack.rb
@@ -60,7 +60,7 @@ module VagrantPlugins
           @logger.info "Waiting for the stack with id #{stack_id} to be built..."
           env[:ui].info(I18n.t('vagrant_openstack.waiting_for_stack'))
           config = env[:machine].provider_config
-          timeout(config.stack_create_timeout, Errors::Timeout) do
+          Timeout.timeout(config.stack_create_timeout, Errors::Timeout) do
             stack_status = 'CREATE_IN_PROGRESS'
             until stack_status == 'CREATE_COMPLETE'
               @logger.debug('Waiting for stack to be CREATED')

--- a/source/lib/vagrant-openstack-provider/action/delete_server.rb
+++ b/source/lib/vagrant-openstack-provider/action/delete_server.rb
@@ -32,7 +32,7 @@ module VagrantPlugins
           @logger.info "Waiting for the instance with id #{instance_id} to be deleted..."
           env[:ui].info(I18n.t('vagrant_openstack.waiting_deleted'))
           config = env[:machine].provider_config
-          timeout(config.server_delete_timeout, Errors::Timeout) do
+          Timeout.timeout(config.server_delete_timeout, Errors::Timeout) do
             delete_ok = false
             until delete_ok
               begin

--- a/source/lib/vagrant-openstack-provider/action/delete_stack.rb
+++ b/source/lib/vagrant-openstack-provider/action/delete_stack.rb
@@ -57,7 +57,7 @@ module VagrantPlugins
           @logger.info "Waiting for the stack with id #{stack_id} to be deleted..."
           env[:ui].info(I18n.t('vagrant_openstack.waiting_for_stack_deleted'))
           config = env[:machine].provider_config
-          timeout(config.stack_delete_timeout, Errors::Timeout) do
+          Timeout.timeout(config.stack_delete_timeout, Errors::Timeout) do
             stack_status = 'DELETE_IN_PROGRESS'
             until stack_status == 'DELETE_COMPLETE'
               @logger.debug('Waiting for stack to be DELETED')

--- a/source/lib/vagrant-openstack-provider/action/wait_active.rb
+++ b/source/lib/vagrant-openstack-provider/action/wait_active.rb
@@ -18,7 +18,7 @@ module VagrantPlugins
             env[:ui].info(I18n.t('vagrant_openstack.waiting_start'))
             client = env[:openstack_client].nova
             config = env[:machine].provider_config
-            timeout(config.server_active_timeout, Errors::Timeout) do
+            Timeout.timeout(config.server_active_timeout, Errors::Timeout) do
               while client.get_server_details(env, env[:machine].id)['status'] != 'ACTIVE'
                 sleep @retry_interval
                 @logger.info('Waiting for server to be active')

--- a/source/lib/vagrant-openstack-provider/action/wait_stop.rb
+++ b/source/lib/vagrant-openstack-provider/action/wait_stop.rb
@@ -18,7 +18,7 @@ module VagrantPlugins
             env[:ui].info(I18n.t('vagrant_openstack.waiting_stop'))
             client = env[:openstack_client].nova
             config = env[:machine].provider_config
-            timeout(config.server_stop_timeout, Errors::Timeout) do
+            Timeout.timeout(config.server_stop_timeout, Errors::Timeout) do
               while client.get_server_details(env, env[:machine].id)['status'] != 'SHUTOFF'
                 sleep @retry_interval
                 @logger.info('Waiting for server to stop')

--- a/source/lib/vagrant-openstack-provider/version_checker.rb
+++ b/source/lib/vagrant-openstack-provider/version_checker.rb
@@ -65,7 +65,7 @@ module VagrantPlugins
 
     # rubocop:disable Lint/HandleExceptions
     def self.check_version
-      timeout(3, Errors::Timeout) do
+      Timeout.timeout(3, Errors::Timeout) do
         VersionChecker.instance.check
       end
     rescue


### PR DESCRIPTION
Changed from timeout to Timeout.timeout to fix deprecation warnings