### PR TITLE
Add Vagrant 1.9 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,7 @@ matrix:
 
     - rvm: 2.2.5
       env: VAGRANT_VERSION=v1.8.7 BUNDLER_VERSION=1.12.5
+    - rvm: 2.2.5
+      env: VAGRANT_VERSION=v1.9.1 BUNDLER_VERSION=1.12.5
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     - rvm: 2.0.0
       env: VAGRANT_VERSION=v1.7.4 BUNDLER_VERSION=1.10.5
 
-    - rvm: 2.2.3
-      env: VAGRANT_VERSION=v1.8.5 BUNDLER_VERSION=1.12.5
+    - rvm: 2.2.5
+      env: VAGRANT_VERSION=v1.8.7 BUNDLER_VERSION=1.12.5
 
 sudo: false

--- a/source/Gemfile
+++ b/source/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'vagrant', git: 'https://github.com/mitchellh/vagrant.git', tag: 'v1.8.5'
+  gem 'vagrant', git: 'https://github.com/mitchellh/vagrant.git', tag: 'v1.9.1'
   # FIXME: Hack to allow Vagrant v1.6.5 to install for tests. Remove when
   # support for 1.6.5 is dropped.
   gem 'rack', '< 2'

--- a/source/Gemfile
+++ b/source/Gemfile
@@ -7,10 +7,6 @@ group :development do
   # FIXME: Hack to allow Vagrant v1.6.5 to install for tests. Remove when
   # support for 1.6.5 is dropped.
   gem 'rack', '< 2'
-  # FIXME: Version 1.4.0 of the ruby_dep gem added a constraint on the Ruby
-  # version being >=2.2.5. This pin to ruby_dep 1.3.1 can be removed when the
-  # next Vagrant version after 1.8.5 is released.
-  gem 'ruby_dep', '~> 1.3.1'
   gem 'appraisal', '1.0.0'
   gem 'rubocop', '0.29.0', require: false
   gem 'coveralls', require: false

--- a/source/spec/vagrant-openstack-provider/client/nova_spec.rb
+++ b/source/spec/vagrant-openstack-provider/client/nova_spec.rb
@@ -459,7 +459,7 @@ describe VagrantPlugins::Openstack::NovaClient do
           {
             'Accept' => 'application/json',
             'Accept-Encoding' => 'gzip, deflate',
-            'User-Agent' => 'Ruby',
+            'User-Agent' => /.*/,
             'X-Auth-Token' => '123456'
           })
           .to_return(status: 200, body: '

--- a/source/vagrant-openstack-provider.gemspec
+++ b/source/vagrant-openstack-provider.gemspec
@@ -18,7 +18,9 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'sshkey', '1.6.1'
   gem.add_dependency 'colorize', '0.7.3'
 
-  gem.add_development_dependency 'rake'
+  # Constraint rake to properly handle deprecated method usage
+  # from within rspec 3.1.z
+  gem.add_development_dependency 'rake', '~> 11.3.0'
   gem.add_development_dependency 'rspec', '~> 3.1.0'
   gem.add_development_dependency 'rspec-its', '~> 1.0.1'
   gem.add_development_dependency 'rspec-expectations', '~> 3.1.2'

--- a/source/vagrant-openstack-provider.gemspec
+++ b/source/vagrant-openstack-provider.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/ggiamarchi/vagrant-openstack-provider'
   gem.license       = 'MIT'
 
-  gem.add_dependency 'json', '1.8.3'
-  gem.add_dependency 'rest-client', '~> 1.6.0'
+  gem.add_dependency 'json', '>= 1.8.1', '< 3.0'
+  gem.add_dependency 'rest-client', '>= 1.6.0', '< 3.0'
   gem.add_dependency 'terminal-table', '1.4.5'
   gem.add_dependency 'sshkey', '1.6.1'
   gem.add_dependency 'colorize', '0.7.3'


### PR DESCRIPTION
This patchset adds Vagrant 1.9.1 to the Travis testsuite and updates gem dependencies for compatibility.