### PR TITLE
Handling of asynchronous floating IP assignment

### DIFF
--- a/source/lib/vagrant-openstack-provider/client/nova.rb
+++ b/source/lib/vagrant-openstack-provider/client/nova.rb
@@ -145,6 +145,19 @@ module VagrantPlugins
         end
       end
 
+      def check_assigned_floating_ip(env, server_id, floating_ip)
+        instance_exists do
+          addresses = get_server_details(env, server_id)['addresses']
+          addresses.each do |_, network|
+            network.each do |network_detail|
+              return true if network_detail['addr'] == floating_ip
+            end
+          end
+
+          return false
+        end
+      end
+
       def import_keypair(env, public_key)
         keyname = "vagrant-generated-#{Kernel.rand(36**8).to_s(36)}"
 

--- a/source/lib/vagrant-openstack-provider/config.rb
+++ b/source/lib/vagrant-openstack-provider/config.rb
@@ -218,6 +218,10 @@ module VagrantPlugins
       attr_accessor :stack_delete_timeout
 
       #
+      # @return [Integer]
+      attr_accessor :floating_ip_assign_timeout
+
+      #
       # @return [HttpConfig]
       attr_accessor :http
 
@@ -282,6 +286,7 @@ module VagrantPlugins
         @server_delete_timeout = UNSET_VALUE
         @stack_create_timeout = UNSET_VALUE
         @stack_delete_timeout = UNSET_VALUE
+        @floating_ip_assign_timeout = UNSET_VALUE
         @meta_args_support = UNSET_VALUE
         @http = HttpConfig.new
         @use_legacy_synced_folders = UNSET_VALUE
@@ -390,6 +395,7 @@ module VagrantPlugins
         @server_delete_timeout = 200 if @server_delete_timeout == UNSET_VALUE
         @stack_create_timeout = 200 if @stack_create_timeout == UNSET_VALUE
         @stack_delete_timeout = 200 if @stack_delete_timeout == UNSET_VALUE
+        @floating_ip_assign_timeout = 200 if @floating_ip_assign_timeout == UNSET_VALUE
         @meta_args_support = false if @meta_args_support == UNSET_VALUE
         @networks = nil if @networks.empty?
         @volumes = nil if @volumes.empty?

--- a/source/locales/en.yml
+++ b/source/locales/en.yml
@@ -69,6 +69,8 @@ en:
       Rsyncing folder: %{hostpath} => %{guestpath}
     using_floating_ip: |-
       Using floating IP %{floating_ip}
+    waiting_for_floating_ip: |-
+      Waiting for floating IP %{floating_ip} to be assigned...
     waiting_for_build: |-
       Waiting for the server to be built...
     waiting_for_ssh: |-

--- a/source/spec/vagrant-openstack-provider/action/create_server_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/create_server_spec.rb
@@ -109,10 +109,12 @@ describe VagrantPlugins::Openstack::Action::CreateServer do
         allow(@action).to receive(:waiting_for_server_to_be_built)
         allow(@action).to receive(:attach_volumes)
         allow(@action).to receive(:waiting_for_server_to_be_reachable)
+        allow(@action).to receive(:waiting_for_floating_ip_to_be_assigned)
 
         expect(@action).to receive(:waiting_for_server_to_be_built).with(env, '45678')
         expect(@action).to receive(:assign_floating_ip).with(env, '45678').and_return('1.2.3.4')
         expect(@action).to receive(:attach_volumes).with(env, '45678', [{ id: 'vol-01', device: nil }])
+        expect(@action).to receive(:waiting_for_floating_ip_to_be_assigned).with(env, '45678')
 
         @action.call(env)
       end


### PR DESCRIPTION
## Overview

When vagrant is run with an openstack-compatible backend which assigns
floating IPs asynchronously, it fails with "Vagrant was unable to resolve
a valid ip to ssh on your OpenStack instance".

This happens because vagrant-openstack-provider tries to get the assigned
IP of the virtual machine immediately after sending the floating IP
assignment command.

This issue was found when using vagrant with [synnefo](https://www.synnefo.org/)
as the backend.

With this patch, vagrant will wait until the floating IP is assigned before
continuing.

## Notes

It should be noted that many implementations do not assume that the IP is immediately assigned, but wait/poll until it appears on the server information.

These include what Ansible and the official Shade library do.
Here is a chain of calls that Ansible does:

1. [Ansible os\_floating\_ip.py:main](https://github.com/ansible/ansible/blob/829c0b8f6284ec37e36f1454d7d3640415239cb2/lib/ansible/modules/cloud/openstack/os_floating_ip.py#L227)
1. [Shade add\_ips\_to\_server](https://github.com/openstack-infra/shade/blob/71322c7bbc70e24b119d30d6f1aab02934a83583/shade/openstackcloud.py#L5090)
1. [Shade \_add\_auto\_ip](https://github.com/openstack-infra/shade/blob/71322c7bbc70e24b119d30d6f1aab02934a83583/shade/openstackcloud.py#L5035)
1. [Shade create\_floating\_ip](https://github.com/openstack-infra/shade/blob/71322c7bbc70e24b119d30d6f1aab02934a83583/shade/openstackcloud.py#L4443)
1. [Shade \_neutron\_create\_floating\_ip](https://github.com/openstack-infra/shade/blob/71322c7bbc70e24b119d30d6f1aab02934a83583/shade/openstackcloud.py#L4514-L4526)

Also, this patch will probably solve other issues, such as [issue 278](https://github.com/ggiamarchi/vagrant-openstack-provider/issues/278)