### PR TITLE
Respect config.ssh.insert_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,10 +240,10 @@ end
 ### SSH authentication
 
 * `keypair_name` - The name of the key pair register in nova to associate with the VM. The public key should
-  be the matching pair for the private key configured with `config.ssh.private_key_path` on Vagrant.
-* `public_key_path` - if `keypair_name` is not provided, the path to the public key will be used by vagrant to generate a keypair on the OpenStack cloud. The keypair will be destroyed when the VM is destroyed.
+  be the matching pair for the private key configured with `config.ssh.private_key_path` on Vagrant. When `config.ssh.insert_key` is `false`, this is ignored.
+* `public_key_path` - if `keypair_name` is not provided, the path to the public key will be used by vagrant to generate a keypair on the OpenStack cloud. The keypair will be destroyed when the VM is destroyed. When `config.ssh.insert_key` is `false`, this is ignored.
 
-If neither `keypair_name` nor `public_key_path` are set, vagrant will generate a new ssh key and automatically import it in OpenStack.
+If neither `keypair_name` nor `public_key_path` are set, vagrant will generate a new ssh key and automatically import it in OpenStack, unless `config.ssh.insert_key` is `false`.
 
 * `ssh_disabled` - if set to `true`, all ssh actions managed by the provider will be disabled during the `vagrant up`.
    We recommend to use this option only to create private VMs that won't be accessed directly from vagrant. By contrast,

--- a/source/.rubocop.yml
+++ b/source/.rubocop.yml
@@ -25,7 +25,7 @@ Metrics/CyclomaticComplexity:
   Max: 15
 
 Metrics/MethodLength:
-  Max: 60
+  Max: 65
 
 Metrics/LineLength:
   Max: 150

--- a/source/lib/vagrant-openstack-provider/action/create_server.rb
+++ b/source/lib/vagrant-openstack-provider/action/create_server.rb
@@ -73,7 +73,7 @@ module VagrantPlugins
             env[:ui].info(" -- ImageRef        : #{options[:image].id}")
           end
           env[:ui].info(" -- Boot volume     : #{options[:volume_boot][:id]} (#{options[:volume_boot][:device]})") unless options[:volume_boot].nil?
-          env[:ui].info(" -- KeyPair         : #{options[:keypair_name]}")
+          env[:ui].info(" -- KeyPair         : #{options[:keypair_name]}") unless options[:keypair_name].nil?
 
           unless options[:networks].empty?
             formated_networks = ' -- '
@@ -105,7 +105,9 @@ module VagrantPlugins
           unless options[:image].nil?
             log << "image '#{options[:image].name}' (#{options[:image].id}) "
           end
-          log << "and keypair '#{options[:keypair_name]}'"
+          unless options[:keypair_name].nil?
+            log << "and keypair '#{options[:keypair_name]}'"
+          end
 
           @logger.info(log)
 

--- a/source/lib/vagrant-openstack-provider/action/read_ssh_info.rb
+++ b/source/lib/vagrant-openstack-provider/action/read_ssh_info.rb
@@ -40,7 +40,9 @@ module VagrantPlugins
             port: @resolver.resolve_ssh_port(env),
             username: @resolver.resolve_ssh_username(env)
           }
-          hash[:private_key_path] = "#{env[:machine].data_dir}/#{get_keypair_name(env)}" unless config.keypair_name || config.public_key_path
+          if env[:machine].config.ssh.insert_key
+            hash[:private_key_path] = "#{env[:machine].data_dir}/#{get_keypair_name(env)}" unless config.keypair_name || config.public_key_path
+          end
           # Should work silently when https://github.com/mitchellh/vagrant/issues/4637 is fixed
           hash[:log_level] = 'ERROR'
           hash

--- a/source/lib/vagrant-openstack-provider/client/nova.rb
+++ b/source/lib/vagrant-openstack-provider/client/nova.rb
@@ -86,7 +86,7 @@ module VagrantPlugins
             s['imageRef'] = options[:image_ref]
           end
           s['flavorRef'] = options[:flavor_ref]
-          s['key_name'] = options[:keypair]
+          s['key_name'] = options[:keypair] unless options[:keypair].nil?
           s['availability_zone'] = options[:availability_zone] unless options[:availability_zone].nil?
           s['security_groups'] = options[:security_groups] unless options[:security_groups].nil?
           s['user_data'] = Base64.encode64(options[:user_data]) unless options[:user_data].nil?

--- a/source/lib/vagrant-openstack-provider/config.rb
+++ b/source/lib/vagrant-openstack-provider/config.rb
@@ -429,10 +429,12 @@ module VagrantPlugins
         validate_stack_config(errors)
         validate_ssh_timeout(errors)
 
-        if machine.config.ssh.private_key_path
-          puts I18n.t('vagrant_openstack.config.keypair_name_required').yellow unless @keypair_name || @public_key_path
-        else
-          errors << I18n.t('vagrant_openstack.config.private_key_missing') if @keypair_name || @public_key_path
+        if machine.config.ssh.insert_key
+          if machine.config.ssh.private_key_path
+            puts I18n.t('vagrant_openstack.config.keypair_name_required').yellow unless @keypair_name || @public_key_path
+          else
+            errors << I18n.t('vagrant_openstack.config.private_key_missing') if @keypair_name || @public_key_path
+          end
         end
 
         {

--- a/source/lib/vagrant-openstack-provider/config_resolver.rb
+++ b/source/lib/vagrant-openstack-provider/config_resolver.rb
@@ -48,7 +48,9 @@ module VagrantPlugins
 
       def resolve_keypair(env)
         config = env[:machine].provider_config
+        machine_config = env[:machine].config
         nova = env[:openstack_client].nova
+        return nil unless machine_config.ssh.insert_key
         return config.keypair_name if config.keypair_name
         return nova.import_keypair_from_file(env, config.public_key_path) if config.public_key_path
         generate_keypair(env)

--- a/source/spec/vagrant-openstack-provider/action/read_ssh_info_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/read_ssh_info_spec.rb
@@ -43,6 +43,7 @@ describe VagrantPlugins::Openstack::Action::ReadSSHInfo do
     double('ssh_config').tap do |config|
       config.stub(:username) { 'sshuser' }
       config.stub(:port) { nil }
+      config.stub(:insert_key) { true }
     end
   end
 
@@ -164,6 +165,16 @@ describe VagrantPlugins::Openstack::Action::ReadSSHInfo do
             username: 'sshuser',
             private_key_path: '/data/dir/my_keypair_name',
             log_level: 'ERROR')
+        end
+      end
+
+      context 'with neither keypair_name nor public_key_path specified and ssh.insert_key is false' do
+        it 'does not return private_key_path' do
+          ssh_config.stub(:insert_key) { false }
+          config.stub(:floating_ip) { '80.80.80.80' }
+          config.stub(:keypair_name) { nil }
+          config.stub(:public_key_path) { nil }
+          @action.read_ssh_info(env).should eq(host: '80.80.80.80', port: 22, username: 'sshuser', log_level: 'ERROR')
         end
       end
     end

--- a/source/spec/vagrant-openstack-provider/config_resolver_spec.rb
+++ b/source/spec/vagrant-openstack-provider/config_resolver_spec.rb
@@ -93,6 +93,7 @@ describe VagrantPlugins::Openstack::ConfigResolver do
     double('ssh_config').tap do |config|
       config.stub(:username) { nil }
       config.stub(:port) { nil }
+      config.stub(:insert_key) { true }
     end
   end
 
@@ -395,6 +396,16 @@ describe VagrantPlugins::Openstack::ConfigResolver do
         config.stub(:public_key_path) { nil }
         @action.stub(:generate_keypair) { 'my-keypair-imported' }
         @action.resolve_keypair(env).should eq('my-keypair-imported')
+      end
+    end
+
+    context 'with insert_key false' do
+      it 'does nothing and return nil' do
+        config.stub(:keypair_name) { 'my-keypair' }
+        ssh_config.stub(:insert_key) { false }
+        nova.should_not_receive(:import_keypair_from_file)
+        @action.should_not_receive(:generate_keypair)
+        @action.resolve_keypair(env).should be_nil
       end
     end
   end

--- a/source/spec/vagrant-openstack-provider/config_spec.rb
+++ b/source/spec/vagrant-openstack-provider/config_spec.rb
@@ -270,6 +270,7 @@ describe VagrantPlugins::Openstack::Config do
       machine.stub_chain(:env, :root_path).and_return '/'
       ssh.stub(:private_key_path) { 'private key path' }
       ssh.stub(:username) { 'ssh username' }
+      ssh.stub(:insert_key) { true }
       config.stub(:ssh) { ssh }
       machine.stub(:config) { config }
       subject.username = 'foo'
@@ -346,6 +347,16 @@ describe VagrantPlugins::Openstack::Config do
           subject.public_key_path = 'public_key'
           I18n.should_receive(:t).with('vagrant_openstack.config.private_key_missing').and_return error_message
           validation_errors.first.should == error_message
+        end
+      end
+
+      context 'keypair_name or public_key_path is set and ssh.insert_key is false' do
+        it 'should not error' do
+          ssh.stub(:private_key_path) { nil }
+          ssh.stub(:insert_key) { false }
+          subject.public_key_path = 'public_key'
+          I18n.should_not_receive(:t)
+          validation_errors.should be_empty
         end
       end
     end


### PR DESCRIPTION
Skip generating a keypair when config.ssh.insert_key is false.

- [x] Update `README.md`
- [x] Allow `config.ssh.private_key_path` only configuration (without `keypair_name` or `public_key_path`)
- [x] Add tests