### PR TITLE
Fix floating IP assignement

### DIFF
--- a/source/lib/vagrant-openstack-provider/config_resolver.rb
+++ b/source/lib/vagrant-openstack-provider/config_resolver.rb
@@ -37,12 +37,17 @@ module VagrantPlugins
         config = env[:machine].provider_config
         nova = env[:openstack_client].nova
         return config.floating_ip if config.floating_ip
+
         fail Errors::UnableToResolveFloatingIP if config.floating_ip_pool.nil? || config.floating_ip_pool.empty?
+
         @logger.debug 'Searching for available ips'
         free_ip = search_free_ip(config, nova, env)
+        config.floating_ip = free_ip
         return free_ip unless free_ip.nil?
+
         @logger.debug 'Allocate new ip anyway'
         allocated_ip = allocate_ip(config, nova, env)
+        config.floating_ip = allocated_ip
         return allocated_ip unless allocated_ip.nil?
       end
 

--- a/source/spec/vagrant-openstack-provider/config_resolver_spec.rb
+++ b/source/spec/vagrant-openstack-provider/config_resolver_spec.rb
@@ -249,6 +249,7 @@ describe VagrantPlugins::Openstack::ConfigResolver do
               FloatingIP.new('80.81.82.85', 'pool-1', nil)
             end
             config.stub(:floating_ip_pool) { ['pool-1'] }
+            config.stub(:floating_ip=) { nil }
             @action.resolve_floating_ip(env).should eq('80.81.82.85')
           end
         end
@@ -261,6 +262,7 @@ describe VagrantPlugins::Openstack::ConfigResolver do
                FloatingIP.new('80.81.82.83', 'pool-1', nil)]
             end
             config.stub(:floating_ip_pool) { ['pool-1'] }
+            config.stub(:floating_ip=) { nil }
             @action.resolve_floating_ip(env).should eq('80.81.82.83')
           end
         end
@@ -275,6 +277,7 @@ describe VagrantPlugins::Openstack::ConfigResolver do
             FloatingIP.new('80.81.82.84', 'pool-1', nil)
           end
           config.stub(:floating_ip_pool) { ['pool-1'] }
+          config.stub(:floating_ip=) { nil }
           @action.resolve_floating_ip(env).should eq('80.81.82.84')
         end
       end
@@ -294,6 +297,7 @@ describe VagrantPlugins::Openstack::ConfigResolver do
               FloatingIP.new('80.81.82.85', 'pool-1', nil)
             end
             config.stub(:floating_ip_pool) { %w(pool-1 pool-2) }
+            config.stub(:floating_ip=) { nil }
             @action.resolve_floating_ip(env).should eq('80.81.82.85')
           end
         end
@@ -306,6 +310,7 @@ describe VagrantPlugins::Openstack::ConfigResolver do
                FloatingIP.new('80.81.82.83', 'pool-2', nil)]
             end
             config.stub(:floating_ip_pool) { %w(pool-1 pool-2) }
+            config.stub(:floating_ip=) { nil }
             @action.resolve_floating_ip(env).should eq('80.81.82.83')
           end
         end
@@ -322,6 +327,7 @@ describe VagrantPlugins::Openstack::ConfigResolver do
               FloatingIP.new('80.81.82.84', 'pool-1', nil)
             end
             config.stub(:floating_ip_pool) { %w(pool-1 pool-2) }
+            config.stub(:floating_ip=) { nil }
             @action.resolve_floating_ip(env).should eq('80.81.82.84')
           end
         end
@@ -337,6 +343,7 @@ describe VagrantPlugins::Openstack::ConfigResolver do
               FloatingIP.new('80.81.82.84', 'pool-2', nil)
             end
             config.stub(:floating_ip_pool) { %w(pool-1 pool-2) }
+            config.stub(:floating_ip=) { nil }
             @action.resolve_floating_ip(env).should eq('80.81.82.84')
           end
         end
@@ -350,6 +357,7 @@ describe VagrantPlugins::Openstack::ConfigResolver do
             nova.stub(:allocate_floating_ip).with(env, 'pool-1').and_raise Errors::VagrantOpenstackError, message: 'error', code: 404
             nova.stub(:allocate_floating_ip).with(env, 'pool-2').and_raise Errors::VagrantOpenstackError, message: 'error', code: 404
             config.stub(:floating_ip_pool) { %w(pool-1 pool-2) }
+            config.stub(:floating_ip=) { nil }
             expect { @action.resolve_floating_ip(env) }.to raise_error(Errors::VagrantOpenstackError)
           end
         end


### PR DESCRIPTION
Depending on the latency within Neutron to actually assign the floating IP, the plugin doesn't manage to resolve the IP when it tries to access the machine immediately after the assignment request. A race condition is caused by a missing assignment into the machine config object.