### PR TITLE
Enable parallel actions

### DIFF
--- a/source/lib/vagrant-openstack-provider/plugin.rb
+++ b/source/lib/vagrant-openstack-provider/plugin.rb
@@ -25,7 +25,7 @@ module VagrantPlugins
         Config
       end
 
-      provider(:openstack, box_optional: true) do
+      provider(:openstack, box_optional: true, parallel: true) do
         Openstack.init_i18n
         Openstack.init_logging
         VagrantPlugins::Openstack.check_version


### PR DESCRIPTION
The `parallel: true` flag is added to the provider plugin to tell Vagrant that
actions such as `vagrant up` on multiple machines can be run in parallel. This
works almost out of the box, the only hickup is the search for free floating IPs
which needs to be made thread safe using a `Mutex` object.

I've tested this on a four machine setup, with different network settings and a wide
range of different provisioners, including:
- Shell
- File
- Docker
- Ansible

It all worked fine and resulted in a much faster CI pipeline.

Closes #130