### PR TITLE
Discover URLs instead of constructing in neutron

### DIFF
--- a/source/lib/vagrant-openstack-provider/client/neutron.rb
+++ b/source/lib/vagrant-openstack-provider/client/neutron.rb
@@ -25,7 +25,11 @@ module VagrantPlugins
       end
 
       def get_subnets(env)
-        subnets_json = get(env, "#{@session.endpoints[:network]}/subnets")
+        network_response = get(env, "#{@session.endpoints[:network]}")
+        network_resources = JSON.parse(network_response)['resources']
+        subnets_resource = network_resources.find { |x| x['name'] == 'subnet' }
+        subnets_url = subnets_resource['links'].find { |x| x['rel'] == 'self' }['href']
+        subnets_json = get(env, subnets_url)
         subnets = []
         JSON.parse(subnets_json)['subnets'].each do |n|
           subnets << Subnet.new(n['id'], n['name'], n['cidr'], n['enable_dhcp'], n['network_id'])
@@ -36,7 +40,11 @@ module VagrantPlugins
       private
 
       def get_networks(env, all)
-        networks_json = get(env, "#{@session.endpoints[:network]}/networks")
+        network_response = get(env, "#{@session.endpoints[:network]}")
+        network_resources = JSON.parse(network_response)['resources']
+        networks_resource = network_resources.find { |x| x['name'] == 'network' }
+        networks_url = networks_resource['links'].find { |x| x['rel'] == 'self' }['href']
+        networks_json = get(env, networks_url)
         networks = []
         JSON.parse(networks_json)['networks'].each do |n|
           networks << Item.new(n['id'], n['name']) if all || n['tenant_id'].eql?(@session.project_id)

--- a/source/spec/vagrant-openstack-provider/client/neutron_spec.rb
+++ b/source/spec/vagrant-openstack-provider/client/neutron_spec.rb
@@ -37,6 +37,24 @@ describe VagrantPlugins::Openstack::NeutronClient do
   describe 'get_private_networks' do
     context 'with token' do
       it 'returns only private networks for project in session' do
+        stub_request(:get, 'http://neutron')
+          .with(
+            headers:
+            {
+              'Accept' => 'application/json',
+              'X-Auth-Token' => '123456'
+            })
+          .to_return(
+            status: 200,
+            body: '
+              {
+                "resources": [
+                  { "name": "subnet", "collections": "subnets", "links": [{"href": "http://neutron/subnets", "rel": "self"}]},
+                  { "name": "network", "collections": "networks", "links": [{"href": "http://neutron/networks", "rel": "self"}]},
+                  { "name": "port", "collections": "ports", "links": [{"href": "http://neutron/ports", "rel": "self"}]}
+                ]
+              }
+            ')
         stub_request(:get, 'http://neutron/networks')
           .with(
             headers:
@@ -70,6 +88,24 @@ describe VagrantPlugins::Openstack::NeutronClient do
   describe 'get_all_networks' do
     context 'with token' do
       it 'returns all networks for project in session' do
+        stub_request(:get, 'http://neutron')
+          .with(
+            headers:
+            {
+              'Accept' => 'application/json',
+              'X-Auth-Token' => '123456'
+            })
+          .to_return(
+            status: 200,
+            body: '
+              {
+                "resources": [
+                  { "name": "subnet", "collections": "subnets", "links": [{"href": "http://neutron/subnets", "rel": "self"}]},
+                  { "name": "network", "collections": "networks", "links": [{"href": "http://neutron/networks", "rel": "self"}]},
+                  { "name": "port", "collections": "ports", "links": [{"href": "http://neutron/ports", "rel": "self"}]}
+                ]
+              }
+            ')
         stub_request(:get, 'http://neutron/networks')
           .with(
             headers:
@@ -105,6 +141,24 @@ describe VagrantPlugins::Openstack::NeutronClient do
   describe 'get_subnets' do
     context 'with token' do
       it 'returns all available subnets' do
+        stub_request(:get, 'http://neutron')
+          .with(
+            headers:
+            {
+              'Accept' => 'application/json',
+              'X-Auth-Token' => '123456'
+            })
+          .to_return(
+            status: 200,
+            body: '
+              {
+                "resources": [
+                  { "name": "subnet", "collections": "subnets", "links": [{"href": "http://neutron/subnets", "rel": "self"}]},
+                  { "name": "network", "collections": "networks", "links": [{"href": "http://neutron/networks", "rel": "self"}]},
+                  { "name": "port", "collections": "ports", "links": [{"href": "http://neutron/ports", "rel": "self"}]}
+                ]
+              }
+            ')
         stub_request(:get, 'http://neutron/subnets')
           .with(
             headers:


### PR DESCRIPTION
The approach of constructing URLs via string concatenation is brittle
and breaks with projects implementing the openstack API but advertising
URLs with trailing slash. In that case URLs contains two consecutives
slashes ending up in the plugin not working. Instead, discover the
required URLs by parsing the top level response and choosing the URL to
use