### PR TITLE
Handle multiple networks with no floating IP assigned

### DIFF
--- a/source/lib/vagrant-openstack-provider/utils.rb
+++ b/source/lib/vagrant-openstack-provider/utils.rb
@@ -13,7 +13,7 @@ module VagrantPlugins
           end
         end
         fail Errors::UnableToResolveIP if addresses.size == 0
-        if addresses.size == 1
+        if addresses.size == 1 || !env[:machine].provider_config.networks
           net_addresses = addresses.first[1]
         else
           first_network = env[:machine].provider_config.networks[0]


### PR DESCRIPTION
When a VM has multiple addresses but no networks assigned in the config
the current code fails because env[:machine].provider_config.networks is
nil.

The content of addresses:

```
{
  "public"=>[
    {"version"=>6, "addr"=>"PUBLIC_IPV6_ADDRESS"},
    {"version"=>4, "addr"=>"PUBLIC_IPV4_ADDRESS"}
  ],
  "private"=>[
    {"version"=>4, "addr"=>"PRIVATE_IPV4_ADDRESS"}
  ]
}
```

Fixes GH-289