### PR TITLE
Rip out version checks

### DIFF
--- a/source/lib/vagrant-openstack-provider/plugin.rb
+++ b/source/lib/vagrant-openstack-provider/plugin.rb
@@ -28,7 +28,6 @@ module VagrantPlugins
       provider(:openstack, box_optional: true, parallel: true) do
         Openstack.init_i18n
         Openstack.init_logging
-        VagrantPlugins::Openstack.check_version
 
         # Load the actual provider
         require_relative 'provider'
@@ -48,7 +47,6 @@ module VagrantPlugins
       command('openstack') do
         Openstack.init_i18n
         Openstack.init_logging
-        VagrantPlugins::Openstack.check_version
 
         require_relative 'command/main'
         Command::Main


### PR DESCRIPTION
I realize this is a partial fix that's unlikely to be accepted, but let me make the case and we can see where we can end up. These version checks are highly annoying for multiple reasons.

* They require internet access on every command. This is a privacy concern because it leaks when you're using vagrant. It's also not guaranteed to be available.
* They print warnings to stdout which breaks commands like vagrant ssh-config
* There is no way to deactivate them. I know I installed a custom version because I needed fixes not available in a released version.