### PR TITLE
Feature: configure ip_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ __N.B.__
 
 #### Networks
 
+* `ip_version` - What IP version, 4 or 6, should be used to establish the SSH connection to the instance
 * `networks` - Network list the server must be connected on. Can be omitted if only one private network exists
   in the OpenStack project
 

--- a/source/lib/vagrant-openstack-provider/config.rb
+++ b/source/lib/vagrant-openstack-provider/config.rb
@@ -255,7 +255,7 @@ module VagrantPlugins
 
       # Specify the version of ip that should be used to connect to the machine
       #
-      # @reeturn [Integer]
+      # @return [Integer]
       attr_accessor :ip_version
 
       def initialize

--- a/source/lib/vagrant-openstack-provider/config.rb
+++ b/source/lib/vagrant-openstack-provider/config.rb
@@ -253,6 +253,11 @@ module VagrantPlugins
       # @return [Boolean]
       attr_accessor :ssl_verify_peer
 
+      # Specify the version of ip that should be used to connect to the machine
+      #
+      # @reeturn [Integer]
+      attr_accessor :ip_version
+
       def initialize
         @password = UNSET_VALUE
         @openstack_compute_url = UNSET_VALUE
@@ -302,6 +307,7 @@ module VagrantPlugins
         @use_legacy_synced_folders = UNSET_VALUE
         @ssl_ca_file = UNSET_VALUE
         @ssl_verify_peer = UNSET_VALUE
+        @ip_version = UNSET_VALUE
       end
 
       def merge(other)
@@ -374,6 +380,7 @@ module VagrantPlugins
         @user_data = nil if @user_data == UNSET_VALUE
         @metadata = nil if @metadata == UNSET_VALUE
         @ssh_disabled = false if @ssh_disabled == UNSET_VALUE
+        @ip_version = nil if @ip_version == UNSET_VALUE
 
         # The value of use_legacy_synced_folders is used by action chains
         # to determine which synced folder implementation to run.

--- a/source/lib/vagrant-openstack-provider/utils.rb
+++ b/source/lib/vagrant-openstack-provider/utils.rb
@@ -7,24 +7,80 @@ module VagrantPlugins
 
       def get_ip_address(env)
         addresses = env[:openstack_client].nova.get_server_details(env, env[:machine].id)['addresses']
+        # First, try to get a floating ip with the right version. If none of the floating ip is of the right version,
+        # return the first floating ip anyway.
+        fallback = nil
         addresses.each do |_, network|
           network.each do |network_detail|
-            return network_detail['addr'] if network_detail['OS-EXT-IPS:type'] == 'floating'
+            next unless network_detail['OS-EXT-IPS:type'] == 'floating'
+            if env[:machine].provider_config.ip_version.nil?
+              return network_detail['addr']
+            elsif get_ip_version(network_detail['addr']) == env[:machine].provider_config.ip_version
+              return network_detail['addr']
+            end
+            fallback ||= network_detail['addr']
           end
         end
+        return fallback unless fallback.nil?
+
         fail Errors::UnableToResolveIP if addresses.size == 0
+
+        # If only one network, we don't use networks config and return the first IP of the correct version
+        # If no IP for this version, return the first IP anyway
         if addresses.size == 1
           net_addresses = addresses.first[1]
-        else
-          first_network = env[:machine].provider_config.networks[0]
-          if first_network.is_a? String
-            net_addresses = addresses[first_network]
+          fail Errors::UnableToResolveIP if net_addresses.size == 0
+          if env[:machine].provider_config.ip_version.nil?
+            return net_addresses[0]['addr']
           else
-            net_addresses = addresses[first_network[:name]]
+            right_version_ip = filter_by_version(net_addresses, env[:machine].provider_config.ip_version)
+            if right_version_ip.nil?
+              return net_addresses[0]['addr']
+            else
+              return right_version_ip
+            end
           end
         end
-        fail Errors::UnableToResolveIP if net_addresses.size == 0
-        net_addresses[0]['addr']
+
+        # If multiple networks exist, follow the order of the networks config and return the first IP of the correct
+        # version, be it in the first network or not.
+        fallback = nil
+        env[:machine].provider_config.networks.each do |network|
+          if network.is_a? String
+            net_addresses = addresses[network]
+          else
+            net_addresses = addresses[network[:name]]
+          end
+          next if net_addresses.size == 0
+          fallback ||= net_addresses[0]['addr']
+          if env[:machine].provider_config.ip_version.nil?
+            return net_addresses[0]['addr']
+          else
+            right_version_ip = filter_by_version(net_addresses, env[:machine].provider_config.ip_version)
+            if right_version_ip.nil?
+              next
+            else
+              return right_version_ip
+            end
+          end
+        end
+        fail Errors::UnableToResolveIP if fallback.nil?
+        fallback
+      end
+
+      private
+
+      def get_ip_version(ip)
+        (ip.include? '.') ? 4 : 6
+      end
+
+      def filter_by_version(net_addresses, wanted_ip_version)
+        net_addresses.each do |address|
+          if get_ip_version(address['addr']) == wanted_ip_version
+            return address['addr']
+          end
+        end
+        nil
       end
     end
   end

--- a/source/spec/vagrant-openstack-provider/action/read_ssh_info_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/read_ssh_info_spec.rb
@@ -19,6 +19,7 @@ describe VagrantPlugins::Openstack::Action::ReadSSHInfo do
       config.stub(:keypair_name) { nil }
       config.stub(:public_key_path) { nil }
       config.stub(:ssh_disabled) { false }
+      config.stub(:ip_version) { nil }
     end
   end
 

--- a/source/spec/vagrant-openstack-provider/config_spec.rb
+++ b/source/spec/vagrant-openstack-provider/config_spec.rb
@@ -30,6 +30,7 @@ describe VagrantPlugins::Openstack::Config do
     its(:user_data) { should be_nil }
     its(:metadata) { should be_nil }
     its(:ssl_ca_file) { should eq nil }
+    its(:ip_version) { should be_nil }
   end
 
   describe 'overriding defaults' do
@@ -52,7 +53,8 @@ describe VagrantPlugins::Openstack::Config do
       :metadata,
       :availability_zone,
       :public_key_path,
-      :ssl_ca_file].each do |attribute|
+      :ssl_ca_file,
+      :ip_version].each do |attribute|
       it "should not default #{attribute} if overridden" do
         subject.send("#{attribute}=".to_sym, 'foo')
         subject.finalize!

--- a/source/spec/vagrant-openstack-provider/utils_spec.rb
+++ b/source/spec/vagrant-openstack-provider/utils_spec.rb
@@ -6,6 +6,7 @@ describe VagrantPlugins::Openstack::Utils do
       config.stub(:tenant_name) { 'testTenant' }
       config.stub(:server_name) { 'testName' }
       config.stub(:floating_ip) { nil }
+      config.stub(:ip_version) { nil }
     end
   end
 
@@ -34,6 +35,68 @@ describe VagrantPlugins::Openstack::Utils do
 
   describe 'get_ip_address' do
     context 'without config.floating_ip' do
+      context 'with config.ip_version set to 4 and a single network' do
+        it 'returns ipv4 and no ipv6' do
+          config.stub(:ip_version) { 4 }
+          nova.stub(:get_server_details).with(env, '1234id') do
+            {
+              'addresses' => {
+                'net' => [
+                  {
+                    'addr' => '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+                  },
+                  {
+                    'addr' => '13.13.13.13'
+                  }
+                ]
+              }
+            }
+          end
+          expect(@action.get_ip_address(env)).to eq('13.13.13.13')
+        end
+      end
+
+      context 'with config.ip_version set to 6 and a single network' do
+        it 'returns ipv6 and no ipv4' do
+          config.stub(:ip_version) { 6 }
+          nova.stub(:get_server_details).with(env, '1234id') do
+            {
+              'addresses' => {
+                'net' => [
+                  {
+                    'addr' => '13.13.13.13'
+                  },
+                  {
+                    'addr' => '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+                  }
+                ]
+              }
+            }
+          end
+          expect(@action.get_ip_address(env)).to eq('2001:0db8:85a3:0000:0000:8a2e:0370:7334')
+        end
+      end
+
+      context 'with config.ip_version set to 6 and first network in config has only ipv4' do
+        it 'returns ipv6' do
+          config.stub(:ip_version) { 6 }
+          config.stub(:networks) { %w(net-2 net-1) }
+          nova.stub(:get_server_details).with(env, '1234id') do
+            {
+              'addresses' => {
+                'net-1' => [{
+                  'addr' => '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+                }],
+                'net-2' => [{
+                  'addr' => '13.13.13.13'
+                }]
+              }
+            }
+          end
+          expect(@action.get_ip_address(env)).to eq('2001:0db8:85a3:0000:0000:8a2e:0370:7334')
+        end
+      end
+
       context 'with floating ip in nova details' do
         it 'returns floating_ip from nova details' do
           config.stub(:floating_ip) { nil }


### PR DESCRIPTION
Closes https://github.com/ggiamarchi/vagrant-openstack-provider/issues/302
Adds `ip_version` option (4 or 6) to define what IP should be used to ssh into the instance.

Possible important change : it does not use the first network defined in the config at all costs, but checks every network from the config to see if one contains an IP of the desired version, even if it is not the first ranked.

Some "real use" tests should be performed before merging.

I added some unit tests, they might not cover every possible scenario.