### PR TITLE
manage user and project domain separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,11 @@ This provider exposes quite a few provider-specific configuration options:
 
 * `username` - The username with which to access OpenStack.
 * `password` - The API key for accessing OpenStack.
-* `domain_name` - The domain name when using identity API version 3 of keystone
+* `domain_name` - The domain name when using identity API version 3 of keystone (Overrides user and project domain)
+* `user_domain_name` - The OpenStack user domain name when using identity API version 3 of keystone
 * `tenant_name` - The OpenStack project name to work on
 * `project_name` - The OpenStack project name used in identity v3
+* `project_domain_name` - The OpenStack project domain name used in identity v3
 * `identity_api_version` - The identity version to use : 2 or 3. If not provided, vagrant will use 2 by default.
 * `region` - The OpenStack region to work on
 * `openstack_auth_url` - The endpoint to authenticate against.

--- a/samples/06_keystone_v3/Vagrantfile
+++ b/samples/06_keystone_v3/Vagrantfile
@@ -15,7 +15,8 @@ Vagrant.configure('2') do |config|
     os.identity_api_version             = '3'
     os.openstack_auth_url               = ENV['OS_AUTH_URL']
     os.project_name                     = ENV['OS_PROJECT_NAME']
-    os.domain_name                      = ENV['OS_PROJECT_DOMAIN_ID']
+    os.user_domain_name                 = ENV['OS_USER_DOMAIN_ID']
+    os.project_domain_name              = ENV['OS_PROJECT_DOMAIN_ID']
     os.username                         = ENV['OS_USERNAME']
     os.password                         = ENV['OS_PASSWORD']
     os.region                           = ENV['OS_REGION_NAME']

--- a/source/lib/vagrant-openstack-provider/client/keystone.rb
+++ b/source/lib/vagrant-openstack-provider/client/keystone.rb
@@ -96,7 +96,7 @@ module VagrantPlugins
                 user: {
                   name: config.username,
                   domain: {
-                    name: config.domain_name
+                    name: config.user_domain_name
                   },
                   password: '****'
                 }
@@ -105,7 +105,7 @@ module VagrantPlugins
             scope: {
               project: {
                 name: config.project_name,
-                domain: { name: config.domain_name }
+                domain: { name: config.project_domain_name }
               }
             }
           }

--- a/source/locales/en.yml
+++ b/source/locales/en.yml
@@ -146,7 +146,11 @@ en:
         settings causes the OpenStack provider to fall back to an old synced
         folder implementation instead of using standard Vagrant synced folders.
       domain_required: |-
-        A domain is required when using identity API version 3
+        A domain is required when using identity API version 3. You need to specify domain_name or (project_domain_name and user_domain_name)
+      user_domain_required: |-
+        A user domain is required when specifying a project domain using identity API version 3.
+      project_domain_required: |-
+        A project domain is required when specifying a user domain using identity API version 3.
       project_name_required: |-
         A project name is required when using identity API version 3
       invalid_interface_type: |-

--- a/source/spec/vagrant-openstack-provider/action/connect_openstack_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/connect_openstack_spec.rb
@@ -305,7 +305,8 @@ describe VagrantPlugins::Openstack::Action::ConnectOpenstack do
         end
         env[:openstack_client].stub(:neutron)  { neutron }
         env[:openstack_client].stub(:glance)   { glance }
-        config.stub(:domain_name) { 'dummy' }
+        config.stub(:user_domain_name) { 'dummy' }
+        config.stub(:project_domain_name) { 'dummy' }
         config.stub(:identity_api_version) { '3' }
 
         @action.call(env)

--- a/source/spec/vagrant-openstack-provider/client/keystone_spec.rb
+++ b/source/spec/vagrant-openstack-provider/client/keystone_spec.rb
@@ -178,7 +178,8 @@ describe VagrantPlugins::Openstack::KeystoneClient do
     # V3
     context 'with good credentials v3' do
       it 'store token and tenant id' do
-        config.stub(:domain_name) { 'dummy' }
+        config.stub(:user_domain_name) { 'dummy' }
+        config.stub(:project_domain_name) { 'dummy' }
         config.stub(:identity_api_version) { '3' }
         config.stub(:openstack_auth_url) { 'http://keystoneAuthV3' }
 
@@ -200,7 +201,8 @@ describe VagrantPlugins::Openstack::KeystoneClient do
 
     context 'with wrong credentials v3' do
       it 'raise an unauthorized error ' do
-        config.stub(:domain_name) { 'dummy' }
+        config.stub(:user_domain_name) { 'dummy' }
+        config.stub(:project_domain_name) { 'dummy' }
         config.stub(:identity_api_version) { '3' }
         config.stub(:openstack_auth_url) { 'http://keystoneAuthV3' }
 


### PR DESCRIPTION
Manage the project and user domain_name separately.
resolves #334