### PR TITLE
config: add scope_domain config variable.

### DIFF
--- a/source/lib/vagrant-openstack-provider/client/keystone.rb
+++ b/source/lib/vagrant-openstack-provider/client/keystone.rb
@@ -105,7 +105,7 @@ module VagrantPlugins
             scope: {
               project: {
                 name: config.project_name,
-                domain: { name: config.domain_name }
+                domain: { name: config.scope_domain }
               }
             }
           }

--- a/source/lib/vagrant-openstack-provider/config.rb
+++ b/source/lib/vagrant-openstack-provider/config.rb
@@ -72,6 +72,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :domain_name
 
+      # The domain name to access Openstack, this defaults to Default.
+      #
+      # @return [String]
+      attr_accessor :scope_domain
+
       # The name of the keypair to use.
       #
       # @return [String]
@@ -289,6 +294,7 @@ module VagrantPlugins
         @security_groups = UNSET_VALUE
         @user_data = UNSET_VALUE
         @metadata = UNSET_VALUE
+        @scope_domain = UNSET_VALUE
         @ssh_disabled = UNSET_VALUE
         @server_create_timeout = UNSET_VALUE
         @server_active_timeout = UNSET_VALUE
@@ -363,6 +369,7 @@ module VagrantPlugins
         @server_name = nil if @server_name == UNSET_VALUE
         @username = nil if @username == UNSET_VALUE
         @domain_name = 'Default' if @domain_name == UNSET_VALUE
+        @scope_domain = @domain_name if @scope_domain == UNSET_VALUE
         @floating_ip = nil if @floating_ip == UNSET_VALUE
         @floating_ip_pool = nil if @floating_ip_pool == UNSET_VALUE
         @floating_ip_pool_always_allocate = false if floating_ip_pool_always_allocate == UNSET_VALUE

--- a/source/spec/vagrant-openstack-provider/action/connect_openstack_spec.rb
+++ b/source/spec/vagrant-openstack-provider/action/connect_openstack_spec.rb
@@ -306,6 +306,7 @@ describe VagrantPlugins::Openstack::Action::ConnectOpenstack do
         env[:openstack_client].stub(:neutron)  { neutron }
         env[:openstack_client].stub(:glance)   { glance }
         config.stub(:domain_name) { 'dummy' }
+        config.stub(:scope_domain) { 'dummy' }
         config.stub(:identity_api_version) { '3' }
 
         @action.call(env)

--- a/source/spec/vagrant-openstack-provider/client/keystone_spec.rb
+++ b/source/spec/vagrant-openstack-provider/client/keystone_spec.rb
@@ -179,6 +179,7 @@ describe VagrantPlugins::Openstack::KeystoneClient do
     context 'with good credentials v3' do
       it 'store token and tenant id' do
         config.stub(:domain_name) { 'dummy' }
+        config.stub(:scope_domain) { 'dummy' }
         config.stub(:identity_api_version) { '3' }
         config.stub(:openstack_auth_url) { 'http://keystoneAuthV3' }
 
@@ -201,6 +202,7 @@ describe VagrantPlugins::Openstack::KeystoneClient do
     context 'with wrong credentials v3' do
       it 'raise an unauthorized error ' do
         config.stub(:domain_name) { 'dummy' }
+        config.stub(:scope_domain) { 'dummy' }
         config.stub(:identity_api_version) { '3' }
         config.stub(:openstack_auth_url) { 'http://keystoneAuthV3' }
 


### PR DESCRIPTION
This allows more flexible scoped authentication requests. Existing
Vagrant file should work the same due to the scope_domain defaulting to
domain_name.
Fixes: #361 

Signed-off-by: Jan Fajerski <jfajerski@suse.com>