### PR TITLE
Version checker improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,13 @@ log level (for instance `VAGRANT_LOG=debug`). If you want only OpenStack provide
 logs use the variable `VAGRANT_OPENSTACK_LOG`. if both variables are set, `VAGRANT_LOG`
 takes precedence.
 
+### Version checker
+
+Each time Vagrant OpenStack Provider runs it checks the installed plugin version and
+print a warning on stderr if the plugin is not up-to-date.
+
+If for any reason you need to disable this check, set the environment variable
+`VAGRANT_OPENSTACK_VERSION_CKECK` to value `DISABLED` prior to run vagrant.
 
 ### CentOS/RHEL/Fedora (sudo: sorry, you must have a tty to run sudo)
 

--- a/source/spec/vagrant-openstack-provider/version_checker_spec.rb
+++ b/source/spec/vagrant-openstack-provider/version_checker_spec.rb
@@ -31,8 +31,8 @@ describe VagrantPlugins::Openstack::VersionChecker do
   def assert_version_is(expected_status, latest, current)
     stub_const('VagrantPlugins::Openstack::VERSION', current)
     version.stub(:version) { latest }
-    @checker.stub(:print)
-    expect(@checker).to receive(:print) unless expected_status == :latest
+    @checker.stub(:print_message)
+    expect(@checker).to receive(:print_message) unless expected_status == :latest
     @checker.check
     expect(@checker.status).to eq(expected_status)
   end


### PR DESCRIPTION
Version checker improvements

* Version checker can now be disabled
* Version checker does not print anymore on stdout. It prints on stderr instead
* In case of error when latest version number is fetched it does not
  trigger an error anymore. It's now best effort

To disable version check

```bash
$ VAGRANT_OPENSTACK_VERSION_CKECK=DISABLED vagrant ... 
```

see #358 