### PR TITLE
(#367) Use Cinder v2 API if available

### DIFF
--- a/source/lib/vagrant-openstack-provider/client/cinder.rb
+++ b/source/lib/vagrant-openstack-provider/client/cinder.rb
@@ -17,7 +17,8 @@ module VagrantPlugins
       end
 
       def get_all_volumes(env)
-        volumes_json = get(env, "#{@session.endpoints[:volume]}/volumes/detail")
+        endpoint = @session.endpoints[:volumev2] || @session.endpoints[:volume]
+        volumes_json = get(env, "#{endpoint}/volumes/detail")
         JSON.parse(volumes_json)['volumes'].map do |volume|
           name = volume['display_name']
           name = volume['name'] if name.nil? # To be compatible with cinder api v1 and v2

--- a/source/spec/vagrant-openstack-provider/client/cinder_spec.rb
+++ b/source/spec/vagrant-openstack-provider/client/cinder_spec.rb
@@ -31,12 +31,14 @@ describe VagrantPlugins::Openstack::CinderClient do
   before :each do
     session.token = '123456'
     session.project_id = 'a1b2c3'
-    session.endpoints = { volume: 'http://cinder' }
     @cinder_client = VagrantPlugins::Openstack.cinder
   end
 
   describe 'get_all_volumes' do
-    context 'on api v1' do
+    context 'on api v1 on volume' do
+      before :each do
+        session.endpoints = { volume: 'http://cinder' }
+      end
       it 'returns volumes with details' do
         stub_request(:get, 'http://cinder/volumes/detail')
           .with(
@@ -82,9 +84,62 @@ describe VagrantPlugins::Openstack::CinderClient do
       end
     end
 
-    context 'on api v2' do
+    context 'on api v2 on volume' do
+      before :each do
+        session.endpoints = { volume: 'http://cinder' }
+      end
+
       it 'returns volumes with details' do
         stub_request(:get, 'http://cinder/volumes/detail')
+          .with(
+            headers:
+                {
+                  'Accept' => 'application/json',
+                  'X-Auth-Token' => '123456'
+                })
+          .to_return(
+            status: 200,
+            body: '
+                {
+                  "volumes": [
+                    {
+                      "id": "987",
+                      "name": "vol-01",
+                      "size": "2",
+                      "status": "available",
+                      "bootable": "true",
+                      "attachments": []
+                    },
+                    {
+                      "id": "654",
+                      "name": "vol-02",
+                      "size": "4",
+                      "status": "in-use",
+                      "bootable": "false",
+                      "attachments": [
+                        {
+                          "server_id": "inst-01",
+                          "device": "/dev/vdc"
+                        }
+                      ]
+                    }
+                  ]
+                }')
+
+        volumes = @cinder_client.get_all_volumes(env)
+
+        expect(volumes).to eq [Volume.new('987', 'vol-01', '2', 'available', 'true', nil, nil),
+                               Volume.new('654', 'vol-02', '4', 'in-use', 'false', 'inst-01', '/dev/vdc')]
+      end
+    end
+
+    context 'on api v2 on volumev2' do
+      before :each do
+        session.endpoints = { volume: 'http://cinder', volumev2: 'http://cinderv2' }
+      end
+
+      it 'returns volumes with details' do
+        stub_request(:get, 'http://cinderv2/volumes/detail')
           .with(
             headers:
                 {


### PR DESCRIPTION
Typically OpenStack has separate endpoints for versions 1, 2, and 3 of Cinder API. This changes the volume code to try the endpoint returned by the volumev2 endpoint, if it exists.