### PR TITLE
Remove Gemfile pin on Rack < 2.0

### DIFF
--- a/source/Gemfile
+++ b/source/Gemfile
@@ -4,9 +4,6 @@ gemspec
 
 group :development do
   gem 'vagrant', git: 'https://github.com/mitchellh/vagrant.git', tag: 'v1.9.8'
-  # FIXME: Hack to allow Vagrant v1.6.5 to install for tests. Remove when
-  # support for 1.6.5 is dropped.
-  gem 'rack', '< 2'
   gem 'appraisal', '1.0.0'
   gem 'rubocop', '0.29.0', require: false
   gem 'coveralls', require: false


### PR DESCRIPTION
This pin was added to keep tests against Vagrant 1.6 passing. This commit
removes the pin as support for Vagrant 1.6 was dropped in commit 0dffdf2.