### PR TITLE
Update Ruby versions in Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ matrix:
   include:
     - rvm: 2.2.5
       env: VAGRANT_VERSION=v1.9.8
-    - rvm: 2.2.5
+    - rvm: 2.4.4
       env: VAGRANT_VERSION=v2.0.4
-    - rvm: 2.2.5
+    - rvm: 2.4.4
       env: VAGRANT_VERSION=v2.1.2
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ matrix:
     - rvm: 2.4.4
       env: VAGRANT_VERSION=v2.0.4
     - rvm: 2.4.4
-      env: VAGRANT_VERSION=v2.1.2
+      env: VAGRANT_VERSION=v2.1.4
 
 sudo: false

--- a/source/spec/vagrant-openstack-provider/client/glance_spec.rb
+++ b/source/spec/vagrant-openstack-provider/client/glance_spec.rb
@@ -111,7 +111,7 @@ describe VagrantPlugins::Openstack::GlanceClient do
   describe 'get_api_version_list' do
     it 'returns version list' do
       stub_request(:get, 'http://glance/')
-        .with(header: { 'Accept' => 'application/json' })
+        .with(headers: { 'Accept' => 'application/json' })
         .to_return(
           status: 200,
           body: '{

--- a/source/spec/vagrant-openstack-provider/client/neutron_spec.rb
+++ b/source/spec/vagrant-openstack-provider/client/neutron_spec.rb
@@ -138,7 +138,7 @@ describe VagrantPlugins::Openstack::NeutronClient do
     context 'basic' do
       it 'returns version list' do
         stub_request(:get, 'http://neutron/')
-          .with(header: { 'Accept' => 'application/json' })
+          .with(headers: { 'Accept' => 'application/json' })
           .to_return(
             status: 200,
             body: '{

--- a/source/vagrant-openstack-provider.gemspec
+++ b/source/vagrant-openstack-provider.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec', '~> 3.1.0'
   gem.add_development_dependency 'rspec-its', '~> 1.0.1'
   gem.add_development_dependency 'rspec-expectations', '~> 3.1.2'
-  gem.add_development_dependency 'webmock', '~> 1.18.0'
+  gem.add_development_dependency 'webmock', '~> 3.4.2'
   gem.add_development_dependency 'fakefs', '~> 0.5.2'
 
   gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)


### PR DESCRIPTION
Vagrant 2.0 and 2.1 both ship with a bundled Ruby 2.4.4. This commit updates
the Travis matrix to test those Vagrant versions with 2.4.4 instead of 2.2.5.