### PR TITLE
Merge configuration volume_boot hashes

### DIFF
--- a/source/lib/vagrant-openstack-provider/config.rb
+++ b/source/lib/vagrant-openstack-provider/config.rb
@@ -337,7 +337,7 @@ module VagrantPlugins
 
             if [:@networks, :@volumes, :@rsync_includes, :@rsync_ignore_files, :@floating_ip_pool, :@stacks].include? key
               result.instance_variable_set(key, value) unless value.empty?
-            elsif [:@http].include? key
+            elsif [:@http, :@volume_boot].include? key
               result.instance_variable_set(key, instance_variable_get(key).merge(other.instance_variable_get(key))) if value != UNSET_VALUE
             else
               result.instance_variable_set(key, value) if value != UNSET_VALUE

--- a/source/spec/vagrant-openstack-provider/config_spec.rb
+++ b/source/spec/vagrant-openstack-provider/config_spec.rb
@@ -257,6 +257,26 @@ describe VagrantPlugins::Openstack::Config do
         end
       end
     end
+
+    it 'should merge volume_boot hashes' do
+      global_config = foo_class.new
+      global_config.volume_boot = { delete_on_destroy: true,
+                                    size: 8 }
+
+      vm_config = foo_class.new
+      vm_config.volume_boot = { image: 'big_windows_vm',
+                                size: 32 }
+
+      result = foo_class.new
+      result.volume_boot = {}
+
+      result = result.merge(global_config)
+      result = result.merge(vm_config)
+
+      expect(result.volume_boot).to eq(delete_on_destroy: true,
+                                       image: 'big_windows_vm',
+                                       size: 32)
+    end
   end
 
   describe 'validation' do


### PR DESCRIPTION
This commit updates the merge behavior of the config object to merge
volume_boot hashes together. This allows defaults to be set for all
VMs that are booting from a volume:

    Vagrant.configure('2') do |config|

      # Always delete volumes when VMs are destroyed.
      config.vm.provider :openstack do |os|
        os.volume_boot = {delete_on_destroy: true}
      end

      config.vm.define 'centos1' do |node|
        node.vm.provider :openstack do |os|
          os.volume_boot = {image: 'centos-7.5',
                            size: 20}
        end
      end
    end

Prior to this change, the last `volume_boot` hash specified would overwrite
all configuration set by other provider blocks.