### PR TITLE
Update colorize gem versions

### DIFF
--- a/source/vagrant-openstack-provider.gemspec
+++ b/source/vagrant-openstack-provider.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rest-client', '>= 1.6.0', '< 3.0'
   gem.add_dependency 'terminal-table', '1.4.5'
   gem.add_dependency 'sshkey', '1.6.1'
-  gem.add_dependency 'colorize', '0.7.3'
+  gem.add_dependency 'colorize', '>=0.7.3', '<0.9.0'
   gem.add_dependency 'public_suffix', '2.0.5'
 
   # Constraint rake to properly handle deprecated method usage


### PR DESCRIPTION
Prior to this PR, colorize was pinned to 0.7.3, which could cause
gem dependency issues with other plugins. This PR updates the
colorize gem dependency to allow the latest versions of the gem. The
current version, 0.8.1 released in 2016, is still compatible with
the plugin.